### PR TITLE
chore: update zad-actions plugin to v1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,8 +26,8 @@
     },
     {
       "name": "zad-actions",
-      "description": "Skills voor ZAD deployment: linting, releases en GitHub Actions validatie voor Zelfservice voor Applicatie Deployment",
-      "version": "1.0.0",
+      "description": "Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en deployment debugging voor Zelfservice voor Applicatie Deployment",
+      "version": "1.1.0",
       "author": {
         "name": "Rijks ICT Gilde",
         "email": "ictgilde@minbzk.nl"
@@ -37,7 +37,7 @@
         "repo": "RijksICTGilde/zad-actions"
       },
       "category": "productivity",
-      "tags": ["zad", "deployment", "github-actions", "linting", "release"]
+      "tags": ["zad", "deployment", "github-actions", "linting", "release", "debugging", "workflow"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ claude plugin install logius-standaarden@overheid-plugins
 | Plugin | Skills | Beschrijving | Maintainer |
 |--------|--------|-------------|------------|
 | [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 88 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [Logius](https://github.com/logius-standaarden) |
-| [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 3 | Skills voor ZAD deployment: linting, releases en GitHub Actions validatie | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
+| [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
## Summary

- Update zad-actions plugin version from 1.0.0 to 1.1.0
- Update skill count from 3 to 5
- Update description to reflect new skills
- Add `debugging` and `workflow` tags

## New skills in zad-actions

| Skill | Description |
|-------|-------------|
| `/generate-workflow` | Generate complete deploy/cleanup workflows for repos using zad-actions |
| `/debug-deploy` | Diagnostic decision tree for deployment failures (HTTP errors, token issues, permissions) |

## Existing skills enriched

The 3 existing skills (`/lint`, `/release`, `/validate-action`) have been expanded with detailed instructions.

See: https://github.com/RijksICTGilde/zad-actions/pull/25