### PR TITLE
Voeg developer-overheid plugin toe aan marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -38,6 +38,21 @@
       },
       "category": "productivity",
       "tags": ["zad", "deployment", "github-actions", "linting", "release", "debugging", "workflow"]
+    },
+    {
+      "name": "developer-overheid",
+      "description": "Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source)",
+      "version": "0.1.0",
+      "author": {
+        "name": "David Stotijn",
+        "email": ""
+      },
+      "source": {
+        "source": "github",
+        "repo": "dstotijn/developer-overheid-nl-agent-skills"
+      },
+      "category": "productivity",
+      "tags": ["overheid", "developer", "api", "security", "open-source", "nl-design-system", "standaarden"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overheid Claude Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![plugins](https://img.shields.io/badge/plugins-2-green.svg)](#beschikbare-plugins)
+[![plugins](https://img.shields.io/badge/plugins-3-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
@@ -22,6 +22,7 @@ claude plugin install logius-standaarden@overheid-plugins
 |--------|--------|-------------|------------|
 | [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 88 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [Logius](https://github.com/logius-standaarden) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
+| [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
## Summary

- Voegt de [developer-overheid-nl-agent-skills](https://github.com/dstotijn/developer-overheid-nl-agent-skills) plugin toe aan de marketplace onder de naam `developer-overheid`
- Plugin bevat 9 skills gebaseerd op de kennisbank van [developer.overheid.nl](https://developer.overheid.nl/kennisbank): API's, data, frontend, infra, security, open source, leidraad, programmeertalen en security
- Auteur: David Stotijn, licentie: EUPL-1.2

## Test plan

- [ ] Valideer dat marketplace.json geldig JSON is
- [ ] Controleer dat de GitHub repo `dstotijn/developer-overheid-nl-agent-skills` bereikbaar is
- [ ] Controleer dat de plugin een geldige `.claude-plugin/plugin.json` bevat