### PR TITLE
Voeg NeRDS plugin toe aan marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -53,6 +53,21 @@
       },
       "category": "productivity",
       "tags": ["overheid", "developer", "api", "security", "open-source", "nl-design-system", "standaarden"]
+    },
+    {
+      "name": "nerds",
+      "description": "Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor het ontwerpen, ontwikkelen en inkopen van digitale systemen bij de overheid (gebruikersbehoeften, toegankelijkheid, open source, cloud, veiligheid, privacy, en meer)",
+      "version": "0.1.0",
+      "author": {
+        "name": "MinBZK",
+        "email": ""
+      },
+      "source": {
+        "source": "github",
+        "repo": "MinBZK/NeRDS"
+      },
+      "category": "productivity",
+      "tags": ["overheid", "richtlijnen", "nerds", "toegankelijkheid", "open-source", "cloud", "privacy", "veiligheid", "duurzaamheid"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overheid Claude Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![plugins](https://img.shields.io/badge/plugins-3-green.svg)](#beschikbare-plugins)
+[![plugins](https://img.shields.io/badge/plugins-4-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
@@ -25,6 +25,7 @@ claude plugin install logius-standaarden@overheid-plugins
 | [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 88 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [Logius](https://github.com/logius-standaarden) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
+| [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
## Summary

- Voegt de NeRDS (Nederlandse Richtlijn Digitale Systemen) plugin toe aan de marketplace
- Plugin leeft in [MinBZK/NeRDS](https://github.com/MinBZK/NeRDS) (PR: https://github.com/MinBZK/NeRDS/pull/179)
- 14 skills voor alle 13 richtlijnen + 1 overzichtsskill
- Badge bijgewerkt naar 4 plugins

## Test plan

- [ ] Wacht tot https://github.com/MinBZK/NeRDS/pull/179 gemerged is
- [ ] Valideer dat `marketplace.json` correct is
- [ ] Test installatie: `claude plugin install nerds@overheid-plugins`