### PR TITLE
Bump plugin versies: logius-standaarden, zad-actions en nerds

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     {
       "name": "zad-actions",
       "description": "Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en deployment debugging voor Zelfservice voor Applicatie Deployment",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Rijks ICT Gilde",
         "email": "ictgilde@minbzk.nl"
@@ -57,7 +57,7 @@
     {
       "name": "nerds",
       "description": "Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor het ontwerpen, ontwikkelen en inkopen van digitale systemen bij de overheid (gebruikersbehoeften, toegankelijkheid, open source, cloud, veiligheid, privacy, en meer)",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "MinBZK",
         "email": ""

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "logius-standaarden",
       "description": "Skills voor Nederlandse overheidsstandaarden (Digikoppeling, API Design Rules, OAuth NL, FSC, CloudEvents, BOMOS, en meer)",
-      "version": "1.0.0",
+      "version": "1.1.1",
       "author": {
         "name": "Logius",
         "email": "standaarden@logius.nl"


### PR DESCRIPTION
## Summary

- **logius-standaarden**: 1.0.0 → 1.1.1 (matching upstream plugin.json)
- **zad-actions**: 1.1.0 → 1.2.0 (matching upstream plugin.json)
- **nerds**: 0.1.0 → 0.1.1 (upstream release v0.1.1 sinds september 2025)

## Test plan

- [ ] Verify plugins installeren correct met nieuwe versies