### PR TITLE
Bump logius-standaarden plugin naar v1.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "logius-standaarden",
       "description": "Skills voor Nederlandse overheidsstandaarden (Digikoppeling, API Design Rules, OAuth NL, FSC, CloudEvents, BOMOS, en meer)",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "author": {
         "name": "MinBZK",
         "email": "standaarden@logius.nl"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ claude plugin install logius-standaarden@overheid-plugins
 
 | Plugin | Skills | Beschrijving | Maintainer |
 |--------|--------|-------------|------------|
-| [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 88 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [MinBZK](https://github.com/MinBZK) |
+| [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [MinBZK](https://github.com/MinBZK) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |


### PR DESCRIPTION
## Summary

- Bumpt logius-standaarden plugin versie van 1.1.1 naar 1.2.0 in marketplace.json

### Wijzigingen in v1.2.0 (upstream)

- Versiemodel en publicatiekanalen gedocumenteerd
- Bronconflicten per domein gedocumenteerd (9 `conflicts.md` bestanden)
- Repo-telling gecorrigeerd: 88→77 unieke repos
- Dode links gefixt in ls-notif, ls-egov en ls-pub
- Verkeerde status-labels gecorrigeerd voor diverse standaarden

Zie volledige [CHANGELOG](https://github.com/MinBZK/logius-standaarden-plugin/blob/main/CHANGELOG.md#120---2026-02-21)