### PR TITLE
Trigger validate workflow on automated PRs

### DIFF
--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -451,7 +451,19 @@ def create_pr(
         print(f"FOUT: PR aanmaken mislukt: {result.stderr}")
         sys.exit(1)
 
-    return result.stdout.strip()
+    pr_url = result.stdout.strip()
+
+    # Trigger the validate workflow on the PR branch so CI status is reported.
+    # Workflows created by GITHUB_TOKEN don't trigger other workflows, so we
+    # need to explicitly dispatch the validation workflow on this branch.
+    subprocess.run(
+        ["gh", "workflow", "run", "validate.yml", "--ref", branch],
+        capture_output=True,
+        text=True,
+        timeout=SUBPROCESS_TIMEOUT,
+    )
+
+    return pr_url
 
 
 def main() -> None:

--- a/.github/scripts/test_check_versions.py
+++ b/.github/scripts/test_check_versions.py
@@ -731,6 +731,28 @@ class TestCreatePr:
             assert "timeout" in kwargs, f"Missing timeout in call: {call}"
 
     @patch("check_versions.subprocess.run")
+    def test_triggers_validate_workflow(self, mock_run, tmp_path):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text('{"plugins": []}')
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="url\n", stderr="")
+
+        data = {"plugins": []}
+        create_pr(str(marketplace), data, [{"name": "x"}], "my-branch", "title", "body")
+
+        # Find the workflow dispatch call
+        workflow_calls = [
+            call
+            for call in mock_run.call_args_list
+            if call[0][0][:3] == ["gh", "workflow", "run"]
+        ]
+        assert len(workflow_calls) == 1
+        cmd = workflow_calls[0][0][0]
+        assert "validate.yml" in cmd
+        assert "--ref" in cmd
+        assert "my-branch" in cmd
+
+    @patch("check_versions.subprocess.run")
     def test_multi_update_commit_message(self, mock_run, tmp_path):
         marketplace = tmp_path / "marketplace.json"
         marketplace.write_text('{"plugins": []}')

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- PRs created by `GITHUB_TOKEN` don't trigger other workflows (GitHub limitation)
- After creating a bump PR, now explicitly dispatches the validate workflow on the PR branch
- Adds `workflow_dispatch` trigger to `validate.yml` so it can be triggered programmatically

## Test plan

- [x] 90 tests passing locally
- [ ] Merge this, then trigger `check-versions.yml` — the resulting PR should have CI checks