### PR TITLE
Remove email addresses from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,7 @@
     "description": "Claude Code plugins voor de Nederlandse overheid"
   },
   "owner": {
-    "name": "MinBZK",
-    "email": "standaarden@logius.nl"
+    "name": "MinBZK"
   },
   "plugins": [
     {
@@ -14,8 +13,7 @@
       "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 77 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
       "version": "1.3.4",
       "author": {
-        "name": "MinBZK",
-        "email": "standaarden@logius.nl"
+        "name": "MinBZK"
       },
       "source": {
         "source": "github",
@@ -35,8 +33,7 @@
       "description": "Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en deployment debugging voor Zelfservice voor Applicatie Deployment.",
       "version": "1.2.0",
       "author": {
-        "name": "Rijks ICT Gilde",
-        "email": "ictgilde@minbzk.nl"
+        "name": "Rijks ICT Gilde"
       },
       "source": {
         "source": "github",
@@ -58,8 +55,7 @@
       "description": "Dutch Government Developer Knowledge Base (developer.overheid.nl/kennisbank) - guidelines and standards for government software development",
       "version": "0.1.0",
       "author": {
-        "name": "David Stotijn",
-        "email": ""
+        "name": "David Stotijn"
       },
       "source": {
         "source": "github",
@@ -81,8 +77,7 @@
       "description": "Plugin voor de Nederlandse Richtlijn Digitale Systemen (NeRDS). Bevat skills voor 13 richtlijnen die richting geven aan het ontwerpen, ontwikkelen en inkopen van digitale systemen binnen de Nederlandse overheid: gebruikersbehoeften, toegankelijkheid, open source, open standaarden, cloud, veiligheid, privacy, samenwerking, integratie, data, algoritmen, inkoop en duurzaamheid.",
       "version": "0.1.1",
       "author": {
-        "name": "MinBZK",
-        "email": ""
+        "name": "MinBZK"
       },
       "source": {
         "source": "github",


### PR DESCRIPTION
## Summary

- Remove all `email` fields from owner and plugin author entries in marketplace.json
- Email addresses are not required by the schema and shouldn't be published in the catalog