### PR TITLE
feat: voeg internet-nl en geonovum plugins toe aan marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -95,6 +95,50 @@
         "veiligheid",
         "duurzaamheid"
       ]
+    },
+    {
+      "name": "internet-nl",
+      "description": "Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, HSTS, DMARC, DKIM, SPF, STARTTLS, DANE).",
+      "version": "0.1.0",
+      "author": {
+        "name": "MinBZK"
+      },
+      "source": {
+        "source": "github",
+        "repo": "MinBZK/internet-nl-plugin"
+      },
+      "category": "productivity",
+      "tags": [
+        "overheid",
+        "internet-standaarden",
+        "compliance",
+        "security",
+        "dnssec",
+        "tls",
+        "dmarc"
+      ]
+    },
+    {
+      "name": "geonovum",
+      "description": "Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D.",
+      "version": "0.1.0",
+      "author": {
+        "name": "MinBZK"
+      },
+      "source": {
+        "source": "github",
+        "repo": "MinBZK/geonovum-plugin"
+      },
+      "category": "productivity",
+      "tags": [
+        "overheid",
+        "geo",
+        "geostandaarden",
+        "ogc-api",
+        "inspire",
+        "metadata",
+        "nen3610"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overheid Claude Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![plugins](https://img.shields.io/badge/plugins-4-green.svg)](#beschikbare-plugins)
+[![plugins](https://img.shields.io/badge/plugins-6-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
@@ -26,6 +26,8 @@ claude plugin install logius-standaarden@overheid-plugins
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
+| [internet-nl](https://github.com/MinBZK/internet-nl-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [MinBZK](https://github.com/MinBZK) |
+| [geonovum](https://github.com/MinBZK/geonovum-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
## Summary

- Voegt twee nieuwe Claude Code plugins toe aan de overheid-plugins marketplace
- **internet-nl-plugin** (5 skills): compliance testen met internet.nl standaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI, DMARC, DKIM, SPF, STARTTLS, DANE)
- **geonovum-plugin** (6 skills): Geonovum geo-standaarden (OGC API, WMS, WFS, NEN 3610, MIM, INSPIRE, CityGML, 3D Tiles)

## Nieuwe repos

| Plugin | Repository | Skills | Tests |
|--------|-----------|--------|-------|
| internet-nl | [MinBZK/internet-nl-plugin](https://github.com/MinBZK/internet-nl-plugin) | 5 | 56 passing |
| geonovum | [MinBZK/geonovum-plugin](https://github.com/MinBZK/geonovum-plugin) | 6 | 57 passing |

Beide repos volgen dezelfde standaarden als logius-standaarden-plugin:
- EUPL-1.2 licentie
- CI met structuurvalidatie, ruff, markdownlint, pytest
- Release-please voor automatische releases
- Dagelijkse link monitoring (lychee) en content monitoring
- Pre-commit hooks (ruff, markdownlint)
- Branch protection op main met verplichte status checks
- Squash merge only, delete branch on merge

## Kwaliteitscontrole

Alle skills zijn kritisch gereviewed op:
- Correcte API endpoints en rate limits (inet-api batch API volledig herschreven)
- Werkende URLs (5 dode NCSC links vervangen)
- Correcte PDOK service types en endpoints
- Correcte GitHub repo referenties (canonical casing)
- Actuele Forum Standaardisatie status per standaard

## Test plan

- [ ] Marketplace JSON validatie passeert
- [ ] `claude plugin install internet-nl@overheid-plugins` werkt
- [ ] `claude plugin install geonovum@overheid-plugins` werkt
- [ ] Skills triggeren op relevante vragen