### PR TITLE
Revert "Claude/create security baseline skill gon is"

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,21 +139,6 @@
         "metadata",
         "nen3610"
       ]
-    },
-    {
-      "name": "bio-security-baseline",
-      "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
-      "version": "0.2.0",
-      "author": {
-        "name": "MinBZK",
-        "email": ""
-      },
-      "source": {
-        "source": "github",
-        "repo": "djimit/bio-security-baseline"
-      },
-      "category": "security",
-      "tags": ["overheid", "beveiliging", "informatiebeveiliging", "BIO", "BIO2", "ISO27001", "NIS2", "cybersecurity", "security-baseline", "compliance"]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,6 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 - Versie-vergelijking met normalisatie (v-prefix, trailing .0)
 - Tests voor check-versions script
 
-## [1.1.0] - 2026-02-22
-
-### Toegevoegd
-
-- Plugin: bio-security-baseline v0.2.0 (1 skill voor BIO2 informatiebeveiliging)
-  - BIO2-overheidsmaatregelen over 13 domeinen (governance, toegangsbeheer, logging, cryptografie, etc.)
-  - Implementatie-checklist voor ontwikkelaars
-  - Forum Standaardisatie verplichte standaarden (HTTPS/HSTS, TLS, DNSSEC, DMARC, DKIM, SPF, etc.)
-  - NCSC-richtlijnen (TLS 2025-05, webapplicaties, basisprincipes)
-  - Cyberbeveiligingswet (NIS2-implementatie)
-  - EU-regelgeving: Cyber Resilience Act, AI Act, Data Act, eIDAS 2.0
-  - DigiToegankelijk (WCAG), authenticatie- en API-standaarden
-  - Audit en compliance (ENSIA, DigiD Normenkader, internet.nl)
-  - Codevoorbeelden (logging, security headers, security.txt)
-
 ## [1.0.0] - 2026-02-16
 
 ### Toegevoegd

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overheid Claude Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![plugins](https://img.shields.io/badge/plugins-7-green.svg)](#beschikbare-plugins)
+[![plugins](https://img.shields.io/badge/plugins-6-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
@@ -28,7 +28,6 @@ claude plugin install logius-standaarden@overheid-plugins
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
 | [internet-nl](https://github.com/MinBZK/internet-nl-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [MinBZK](https://github.com/MinBZK) |
 | [geonovum](https://github.com/MinBZK/geonovum-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [MinBZK](https://github.com/MinBZK) |
-| [bio-security-baseline](https://github.com/djimit/overheid-claude-plugins) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
Reverts MinBZK/overheid-claude-plugins#17

I just realised it isn't wise to point to plugins hosted by individuals rather than orgs, in particular for security related skills. I'll be in touch for a followup @djimit.