### PR TITLE
Voeg bio-security-baseline plugin toe vanuit MinBZK repo

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,6 +139,31 @@
         "metadata",
         "nen3610"
       ]
+    },
+    {
+      "name": "bio-security-baseline",
+      "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
+      "version": "0.2.0",
+      "author": {
+        "name": "MinBZK"
+      },
+      "source": {
+        "source": "github",
+        "repo": "MinBZK/bio-security-baseline-plugin"
+      },
+      "category": "security",
+      "tags": [
+        "overheid",
+        "beveiliging",
+        "informatiebeveiliging",
+        "BIO",
+        "BIO2",
+        "ISO27001",
+        "NIS2",
+        "cybersecurity",
+        "security-baseline",
+        "compliance"
+      ]
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 - Versie-vergelijking met normalisatie (v-prefix, trailing .0)
 - Tests voor check-versions script
 
+## [1.1.0] - 2026-02-23
+
+### Toegevoegd
+
+- Plugin: bio-security-baseline v0.2.0 (1 skill voor BIO2 informatiebeveiliging)
+  - Source verplaatst van djimit/bio-security-baseline naar MinBZK/bio-security-baseline-plugin
+
 ## [1.0.0] - 2026-02-16
 
 ### Toegevoegd

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overheid Claude Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
-[![plugins](https://img.shields.io/badge/plugins-6-green.svg)](#beschikbare-plugins)
+[![plugins](https://img.shields.io/badge/plugins-7-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
@@ -28,6 +28,7 @@ claude plugin install logius-standaarden@overheid-plugins
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
 | [internet-nl](https://github.com/MinBZK/internet-nl-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [MinBZK](https://github.com/MinBZK) |
 | [geonovum](https://github.com/MinBZK/geonovum-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [MinBZK](https://github.com/MinBZK) |
+| [bio-security-baseline](https://github.com/MinBZK/bio-security-baseline-plugin) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen
 


### PR DESCRIPTION
## Summary

- Voegt bio-security-baseline plugin opnieuw toe aan de marketplace (revert van #20)
- Source verplaatst van `djimit/bio-security-baseline` naar `MinBZK/bio-security-baseline-plugin`
- Plugin biedt 1 skill voor BIO2 informatiebeveiliging

## Wijzigingen

- `marketplace.json`: bio-security-baseline entry met MinBZK repo als source
- `README.md`: plugin tabel bijgewerkt (6 -> 7 plugins)
- `CHANGELOG.md`: 1.1.0 entry toegevoegd