### PR TITLE
Update repo references from MinBZK to developer-overheid-nl

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "description": "Claude Code plugins voor de Nederlandse overheid"
   },
   "owner": {
-    "name": "MinBZK"
+    "name": "developer-overheid-nl"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,5 +33,6 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 - Issue template voor plugin-aanmeldingen
 - PR template
 
-[Unreleased]: https://github.com/MinBZK/overheid-claude-plugins/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/MinBZK/overheid-claude-plugins/releases/tag/v1.0.0
+[Unreleased]: https://github.com/developer-overheid-nl/overheid-claude-plugins/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/developer-overheid-nl/overheid-claude-plugins/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/developer-overheid-nl/overheid-claude-plugins/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
 [![plugins](https://img.shields.io/badge/plugins-7-green.svg)](#beschikbare-plugins)
-[![CI](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/MinBZK/overheid-claude-plugins/actions/workflows/validate.yml)
+[![CI](https://github.com/developer-overheid-nl/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/developer-overheid-nl/overheid-claude-plugins/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
 
@@ -10,7 +10,7 @@ Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 
 ```bash
 # 1. Voeg de marketplace toe
-claude plugin marketplace add MinBZK/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
 
 # 2. Installeer een plugin
 claude plugin install logius-standaarden@overheid-plugins

--- a/demo.tape
+++ b/demo.tape
@@ -1,0 +1,37 @@
+# VHS demo: Installing overheid-plugins marketplace
+# Run with: vhs demo.tape
+
+Output demo.gif
+
+Set Shell "zsh"
+Set FontSize 16
+Set Width 900
+Set Height 500
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 50ms
+Set Padding 20
+
+# Title
+Type "# Overheid Claude Plugins - Marketplace"
+Enter
+Sleep 1s
+
+# Step 1: Add the marketplace
+Type "claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins"
+Enter
+Sleep 3s
+
+# Step 2: Show available marketplaces
+Type "claude plugin marketplace list"
+Enter
+Sleep 3s
+
+# Step 3: Install a plugin
+Type "claude plugin install developer-overheid@overheid-plugins"
+Enter
+Sleep 3s
+
+# Step 4: Show installed plugins
+Type "claude plugin list"
+Enter
+Sleep 5s

--- a/docs/plugin-toevoegen.md
+++ b/docs/plugin-toevoegen.md
@@ -23,7 +23,7 @@ Je plugin moet voldoen aan de [kwaliteitseisen](../CONTRIBUTING.md):
 ### Stap 1: Fork en clone
 
 ```bash
-gh repo fork MinBZK/overheid-claude-plugins --clone
+gh repo fork developer-overheid-nl/overheid-claude-plugins --clone
 cd overheid-claude-plugins
 ```
 
@@ -82,7 +82,7 @@ gh pr create --title "Voeg jouw-plugin toe" --body "Beschrijving van de plugin e
 Zodra je plugin is toegevoegd kunnen gebruikers deze installeren:
 
 ```bash
-claude plugin marketplace add MinBZK/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
 claude plugin install jouw-plugin@overheid-plugins
 ```
 


### PR DESCRIPTION
## Summary

- Update all references from `MinBZK/overheid-claude-plugins` to `developer-overheid-nl/overheid-claude-plugins` after the repo move
- Fix missing `[1.1.0]` link in CHANGELOG.md
- Individual plugin repos (logius-standaarden-plugin, NeRDS, internet-nl-plugin, geonovum-plugin, bio-security-baseline-plugin) remain under MinBZK and are intentionally unchanged

### Files changed
- **README.md** — CI badge URL, marketplace add command
- **CHANGELOG.md** — release URLs, added missing 1.1.0 link
- **docs/plugin-toevoegen.md** — fork command, marketplace add command
- **.claude-plugin/marketplace.json** — owner name
- **demo.tape** — marketplace add command

## Test plan

- [ ] Verify CI badge renders correctly in README
- [ ] Verify `claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins` works
- [ ] Verify all links in CHANGELOG point to correct repo