### PR TITLE
Update plugin repo references after move to developer-overheid-nl

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,11 +13,11 @@
       "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 77 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
       "version": "1.3.4",
       "author": {
-        "name": "MinBZK"
+        "name": "developer-overheid-nl"
       },
       "source": {
         "source": "github",
-        "repo": "MinBZK/logius-standaarden-plugin"
+        "repo": "developer-overheid-nl/standaarden-plugin"
       },
       "category": "productivity",
       "tags": [
@@ -101,11 +101,11 @@
       "description": "Plugin voor het testen en implementeren van moderne internetstandaarden conform internet.nl. Bevat skills voor 5 domeinen: webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API, en implementatiegidsen uit de toolbox-wiki.",
       "version": "0.1.2",
       "author": {
-        "name": "MinBZK"
+        "name": "developer-overheid-nl"
       },
       "source": {
         "source": "github",
-        "repo": "MinBZK/internet-nl-plugin"
+        "repo": "developer-overheid-nl/internet-plugin"
       },
       "category": "productivity",
       "tags": [
@@ -123,11 +123,11 @@
       "description": "Plugin voor Geonovum geo-standaarden voor ruimtelijke data in Nederland. Bevat skills voor 6 domeinen: OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie, en 3D standaarden (CityGML, 3D Tiles).",
       "version": "0.1.3",
       "author": {
-        "name": "MinBZK"
+        "name": "developer-overheid-nl"
       },
       "source": {
         "source": "github",
-        "repo": "MinBZK/geonovum-plugin"
+        "repo": "developer-overheid-nl/geo-plugin"
       },
       "category": "productivity",
       "tags": [

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ claude plugin install logius-standaarden@overheid-plugins
 
 | Plugin | Skills | Beschrijving | Maintainer |
 |--------|--------|-------------|------------|
-| [logius-standaarden](https://github.com/MinBZK/logius-standaarden-plugin) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [MinBZK](https://github.com/MinBZK) |
+| [logius-standaarden](https://github.com/developer-overheid-nl/standaarden-plugin) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
-| [internet-nl](https://github.com/MinBZK/internet-nl-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [MinBZK](https://github.com/MinBZK) |
-| [geonovum](https://github.com/MinBZK/geonovum-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [MinBZK](https://github.com/MinBZK) |
+| [internet-nl](https://github.com/developer-overheid-nl/internet-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [geonovum](https://github.com/developer-overheid-nl/geo-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [bio-security-baseline](https://github.com/MinBZK/bio-security-baseline-plugin) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen


### PR DESCRIPTION
## Summary

Three plugin repos have been renamed and moved to developer-overheid-nl:
- `MinBZK/logius-standaarden-plugin` -> `developer-overheid-nl/standaarden-plugin`
- `MinBZK/internet-nl-plugin` -> `developer-overheid-nl/internet-plugin`
- `MinBZK/geonovum-plugin` -> `developer-overheid-nl/geo-plugin`

Updates marketplace.json source repos, author names, and README plugin table links.

## Related PRs
- https://github.com/developer-overheid-nl/standaarden-plugin/pull/66
- https://github.com/developer-overheid-nl/internet-plugin/pull/17
- https://github.com/developer-overheid-nl/geo-plugin/pull/14

## Test plan
- [ ] Verify marketplace.json source repos point to correct new locations
- [ ] Verify README plugin links work