### PR TITLE
Add publiccode.yml for marketplace repository

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,0 +1,54 @@
+publiccodeYmlVersion: '0.2'
+categories:
+  - collaboration
+  - it-development
+description:
+  nl:
+    features:
+      - Centrale catalogus van Claude Code plugins voor de Nederlandse overheid
+      - Geautomatiseerde validatie van plugin-registraties
+      - Kwaliteitsdashboard voor gepubliceerde plugins
+      - Handleidingen voor het bouwen en toevoegen van plugins
+      - Ondersteuning voor meerdere overheidsorganisaties en standaarden
+    genericName: Plugin marketplace
+    longDescription: >
+      Centrale catalogus (marketplace) van Claude Code plugins voor de Nederlandse
+      overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins
+      publiceren en ontdekken. Bevat plugins voor onder andere Logius standaarden,
+      internetstandaarden (internet.nl), geo-standaarden (Geonovum), de Nederlandse
+      Richtlijn Digitale Systemen (NeRDS), BIO2 beveiligingsbaseline, en meer.
+      Inclusief geautomatiseerde validatie, kwaliteitseisen en documentatie voor
+      pluginontwikkelaars.
+    shortDescription: Centrale catalogus van Claude Code plugins voor de Nederlandse overheid
+  en:
+    features:
+      - Central catalog of Claude Code plugins for the Dutch government
+      - Automated validation of plugin registrations
+      - Quality dashboard for published plugins
+      - Guides for building and adding plugins
+      - Support for multiple government organizations and standards
+    genericName: Plugin marketplace
+    longDescription: >
+      Central catalog (marketplace) of Claude Code plugins for the Dutch government.
+      Through this marketplace, government teams can publish and discover Claude Code
+      plugins. Contains plugins for Logius standards, internet standards (internet.nl),
+      geo-standards (Geonovum), the Dutch Digital Systems Guideline (NeRDS), BIO2
+      security baseline, and more. Includes automated validation, quality requirements,
+      and documentation for plugin developers.
+    shortDescription: Central catalog of Claude Code plugins for the Dutch government
+developmentStatus: stable
+legal:
+  license: EUPL-1.2
+localisation:
+  availableLanguages:
+    - nl
+    - en
+  localisationReady: false
+maintenance:
+  contacts:
+    - name: developer-overheid-nl
+  type: community
+name: overheid-claude-plugins
+releaseDate: '2026-02-12'
+softwareType: standalone/other
+url: https://github.com/developer-overheid-nl/overheid-claude-plugins


### PR DESCRIPTION
## Summary

- Adds a `publiccode.yml` metadata file following the [Standard for Public Code](https://standard.publiccode.net/)
- Describes the marketplace as a central catalog of Claude Code plugins for the Dutch government
- Includes both Dutch and English descriptions, features, and metadata
- Modeled after the existing `publiccode.yml` files in the plugin repositories (standaarden-plugin, internet-plugin, geo-plugin)

## Details

Key fields:
- **name:** overheid-claude-plugins
- **softwareType:** standalone/other
- **developmentStatus:** stable
- **license:** EUPL-1.2
- **categories:** collaboration, it-development
- **languages:** nl, en

## Test plan

- [x] YAML is valid (verified by pre-commit check-yaml hook)
- [ ] Verify the file renders correctly on GitHub
- [ ] Validate against publiccode.yml schema