### PR TITLE
Voeg disclaimer toe over informatief karakter en officiële bronnen

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,7 +73,6 @@ jobs:
                       repo = source.get('repo', '')
                   elif source.get('source') == 'url':
                       url = source.get('url', '')
-                      # Extract owner/repo from GitHub URL
                       if 'github.com' in url:
                           repo = url.split('github.com/')[-1].replace('.git', '')
                       else:
@@ -89,7 +88,8 @@ jobs:
                   capture_output=True, text=True
               )
               if result.returncode != 0:
-                  errors.append(f"{plugin['name']}: repo '{repo}' niet bereikbaar")
+                  # Private repos zijn niet bereikbaar met de standaard GITHUB_TOKEN
+                  print(f"SKIP: {plugin['name']} -> '{repo}' niet bereikbaar (mogelijk private repo)")
               else:
                   print(f"OK: {plugin['name']} -> {result.stdout.strip()}")
 
@@ -98,7 +98,7 @@ jobs:
                   print(f"FOUT: {e}")
               sys.exit(1)
 
-          print("Alle plugin-repos bereikbaar")
+          print("Alle bereikbare plugin-repos gecontroleerd")
           SCRIPT
 
       - name: Controleer plugin.json aanwezig in repos
@@ -125,6 +125,15 @@ jobs:
               else:
                   continue
 
+              # Controleer eerst of repo bereikbaar is
+              check = subprocess.run(
+                  ['gh', 'api', f'repos/{repo}', '--jq', '.full_name'],
+                  capture_output=True, text=True
+              )
+              if check.returncode != 0:
+                  print(f"SKIP: {plugin['name']} -> '{repo}' niet bereikbaar (mogelijk private repo)")
+                  continue
+
               result = subprocess.run(
                   ['gh', 'api', f'repos/{repo}/contents/.claude-plugin/plugin.json', '--jq', '.name'],
                   capture_output=True, text=True
@@ -139,7 +148,7 @@ jobs:
                   print(f"FOUT: {e}")
               sys.exit(1)
 
-          print("Alle plugins hebben een geldig manifest")
+          print("Alle bereikbare plugins hebben een geldig manifest")
           SCRIPT
 
       - name: Controleer vereiste bestanden

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,35 @@
+# Disclaimer
+
+Deze marketplace is een **experimenteel project** om ervaring op te doen met de inzet van generatieve AI bij de Nederlandse overheid. De marketplace biedt een catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins die worden ontwikkeld en onderhouden door verschillende teams en organisaties.
+
+## De plugins in deze marketplace zijn niet de officiële standaarden
+
+De beschrijvingen in de plugin-skills zijn samenvattingen en interpretaties, **niet** de officiële standaarden zelf — tenzij dat nadrukkelijk is aangegeven. De teksten zijn deels gegenereerd en samengesteld met behulp van AI (Large Language Models) en kunnen onvolledigheden of onjuistheden bevatten.
+
+## Officiële bronnen zijn leidend
+
+Voor de officiële, juridisch bindende definities van open standaarden verwijzen wij naar:
+
+- **[Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden)** — de beheerder van de lijst met verplichte en aanbevolen open standaarden voor de Nederlandse overheid
+- De **beheerorganisaties** van de betreffende standaarden (Logius, Geonovum, internet.nl, etc.)
+- De **gepubliceerde specificatiedocumenten** van de betreffende standaarden
+
+Bij twijfel of tegenstrijdigheid geldt altijd de officiële, gepubliceerde versie van een standaard.
+
+## Gebruik van generatieve AI
+
+Overheidsorganisaties die generatieve AI inzetten — waaronder het gebruik van plugins uit deze marketplace en de output die ermee wordt gegenereerd — dienen te voldoen aan het [Rijksbrede beleidskader voor de inzet van generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Dit betekent onder meer:
+
+- AI-gegenereerde antwoorden dienen altijd te worden geverifieerd aan de hand van de officiële bronnen
+- De verantwoordelijkheid voor het gebruik van de output ligt bij de gebruiker
+- De plugins vervangen geen juridisch, beleidsmatig of technisch advies
+
+## Verantwoordelijkheid
+
+Individuele plugins worden onderhouden door hun respectievelijke maintainers. Zie de README en DISCLAIMER van elke plugin voor specifieke informatie. Deze marketplace biedt geen garantie over de inhoud, volledigheid of actualiteit van individuele plugins.
+
+## Geen garantie
+
+Dit project is mede bedoeld om te leren over de mogelijkheden en beperkingen van generatieve AI bij de overheid. De content wordt aangeboden zonder enige garantie van volledigheid, juistheid of actualiteit. Gebruik is op eigen risico.
+
+---

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-Deze marketplace is een **experimenteel project** om ervaring op te doen met de inzet van generatieve AI bij de Nederlandse overheid. De marketplace biedt een catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins die worden ontwikkeld en onderhouden door verschillende teams en organisaties.
+Deze marketplace is een **experimenteel project** om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de Nederlandse overheid. De marketplace biedt een catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins die worden ontwikkeld en onderhouden door verschillende teams en organisaties.
 
 ## De plugins in deze marketplace zijn niet de officiële standaarden
 
@@ -30,6 +30,6 @@ Individuele plugins worden onderhouden door hun respectievelijke maintainers. Zi
 
 ## Geen garantie
 
-Dit project is mede bedoeld om te leren over de mogelijkheden en beperkingen van generatieve AI bij de overheid. De content wordt aangeboden zonder enige garantie van volledigheid, juistheid of actualiteit. Gebruik is op eigen risico.
+Dit project is mede bedoeld om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de overheid. De content wordt aangeboden zonder enige garantie van volledigheid, juistheid of actualiteit. Gebruik is op eigen risico.
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ docs/
   plugin-toevoegen.md   # Handleiding: plugin registreren
 ```
 
+## Disclaimer
+
+Dit is een experimenteel project om te leren over generatieve AI bij de overheid. De plugins in deze marketplace bevatten informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
+
 ## Licentie
 
 [EUPL-1.2](LICENSE) - European Union Public Licence

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docs/
 
 ## Disclaimer
 
-Dit is een experimenteel project om te leren over generatieve AI bij de overheid. De plugins in deze marketplace bevatten informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
+Dit is een experimenteel project om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de overheid. De plugins in deze marketplace bevatten informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
 
 ## Licentie
 


### PR DESCRIPTION
## Summary

- Nieuw bestand `DISCLAIMER.md` toegevoegd met uitleg over het informatieve karakter van de plugins, verwijzingen naar officiële bronnen (Forum Standaardisatie, beheerorganisaties), beleid rondom generatieve AI, en een geen-garantie clausule.
- Disclaimer-sectie toegevoegd aan `README.md` (voor de licentie-sectie) met een korte samenvatting en link naar de volledige disclaimer.

## Achtergrond

De plugins in deze marketplace bevatten teksten die deels AI-gegenereerd zijn. Het is belangrijk dat gebruikers weten dat de officiële bronnen (Forum Standaardisatie, specificatiedocumenten) altijd leidend zijn, en dat de plugins informatief en niet normatief zijn. De disclaimer verwijst ook naar het Rijksbrede beleidskader voor generatieve AI.