### PR TITLE
chore: update repo references after rename

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,13 +11,13 @@
     {
       "name": "logius-standaarden",
       "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 77 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
-      "version": "1.3.4",
+      "version": "0.3.5",
       "author": {
         "name": "developer-overheid-nl"
       },
       "source": {
         "source": "github",
-        "repo": "developer-overheid-nl/standaarden-plugin"
+        "repo": "developer-overheid-nl/skills-standaarden"
       },
       "category": "productivity",
       "tags": [
@@ -99,13 +99,13 @@
     {
       "name": "internet-nl",
       "description": "Plugin voor het testen en implementeren van moderne internetstandaarden conform internet.nl. Bevat skills voor 5 domeinen: webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API, en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "author": {
         "name": "developer-overheid-nl"
       },
       "source": {
         "source": "github",
-        "repo": "developer-overheid-nl/internet-plugin"
+        "repo": "developer-overheid-nl/skills-internet"
       },
       "category": "productivity",
       "tags": [
@@ -127,7 +127,7 @@
       },
       "source": {
         "source": "github",
-        "repo": "developer-overheid-nl/geo-plugin"
+        "repo": "developer-overheid-nl/skills-geo"
       },
       "category": "productivity",
       "tags": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,6 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 - Issue template voor plugin-aanmeldingen
 - PR template
 
-[Unreleased]: https://github.com/developer-overheid-nl/overheid-claude-plugins/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/developer-overheid-nl/overheid-claude-plugins/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/developer-overheid-nl/overheid-claude-plugins/releases/tag/v1.0.0
+[Unreleased]: https://github.com/developer-overheid-nl/skills-marketplace/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/developer-overheid-nl/skills-marketplace/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/developer-overheid-nl/skills-marketplace/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
 [![plugins](https://img.shields.io/badge/plugins-7-green.svg)](#beschikbare-plugins)
-[![CI](https://github.com/developer-overheid-nl/overheid-claude-plugins/actions/workflows/validate.yml/badge.svg)](https://github.com/developer-overheid-nl/overheid-claude-plugins/actions/workflows/validate.yml)
+[![CI](https://github.com/developer-overheid-nl/skills-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/developer-overheid-nl/skills-marketplace/actions/workflows/validate.yml)
 
 Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
 
@@ -10,7 +10,7 @@ Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 
 ```bash
 # 1. Voeg de marketplace toe
-claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/skills-marketplace
 
 # 2. Installeer een plugin
 claude plugin install logius-standaarden@overheid-plugins
@@ -22,12 +22,12 @@ claude plugin install logius-standaarden@overheid-plugins
 
 | Plugin | Skills | Beschrijving | Maintainer |
 |--------|--------|-------------|------------|
-| [logius-standaarden](https://github.com/developer-overheid-nl/standaarden-plugin) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [logius-standaarden](https://github.com/developer-overheid-nl/skills-standaarden) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
-| [internet-nl](https://github.com/developer-overheid-nl/internet-plugin) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
-| [geonovum](https://github.com/developer-overheid-nl/geo-plugin) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [internet-nl](https://github.com/developer-overheid-nl/skills-internet) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [geonovum](https://github.com/developer-overheid-nl/skills-geo) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [bio-security-baseline](https://github.com/MinBZK/bio-security-baseline-plugin) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen

--- a/docs/plugin-toevoegen.md
+++ b/docs/plugin-toevoegen.md
@@ -23,8 +23,8 @@ Je plugin moet voldoen aan de [kwaliteitseisen](../CONTRIBUTING.md):
 ### Stap 1: Fork en clone
 
 ```bash
-gh repo fork developer-overheid-nl/overheid-claude-plugins --clone
-cd overheid-claude-plugins
+gh repo fork developer-overheid-nl/skills-marketplace --clone
+cd skills-marketplace
 ```
 
 ### Stap 2: Voeg je plugin toe aan marketplace.json
@@ -82,7 +82,7 @@ gh pr create --title "Voeg jouw-plugin toe" --body "Beschrijving van de plugin e
 Zodra je plugin is toegevoegd kunnen gebruikers deze installeren:
 
 ```bash
-claude plugin marketplace add developer-overheid-nl/overheid-claude-plugins
+claude plugin marketplace add developer-overheid-nl/skills-marketplace
 claude plugin install jouw-plugin@overheid-plugins
 ```
 

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -48,7 +48,7 @@ maintenance:
   contacts:
     - name: developer-overheid-nl
   type: community
-name: overheid-claude-plugins
+name: skills-marketplace
 releaseDate: '2026-02-12'
 softwareType: standalone/other
-url: https://github.com/developer-overheid-nl/overheid-claude-plugins
+url: https://github.com/developer-overheid-nl/skills-marketplace


### PR DESCRIPTION
## Samenvatting

Update alle interne referenties na repo renames:
- `overheid-claude-plugins` → `skills-marketplace`
- `standaarden-plugin` → `skills-standaarden`
- `internet-plugin` → `skills-internet`
- `geo-plugin` → `skills-geo`

Bijgewerkte bestanden: marketplace.json, publiccode.yml, README, CHANGELOG, docs/plugin-toevoegen.md