### PR TITLE
Rename plugins to neutral names, update standaarden to v0.3.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   },
   "plugins": [
     {
-      "name": "logius-standaarden",
-      "description": "Plugin voor het werken met Logius standaarden voor Nederlandse overheidsinteroperabiliteit. Bevat skills voor 77 GitHub repositories verdeeld over 9 domeinen: API Design Rules, Digikoppeling, Identity & Access Management, FSC, Logboek Dataverwerkingen, CloudEvents & Notificaties, BOMOS governance, E-Government services, en Publicatie & Tooling.",
-      "version": "0.3.5",
+      "name": "standaarden",
+      "description": "Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
+      "version": "0.3.6",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -97,8 +97,8 @@
       ]
     },
     {
-      "name": "internet-nl",
-      "description": "Plugin voor het testen en implementeren van moderne internetstandaarden conform internet.nl. Bevat skills voor 5 domeinen: webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API, en implementatiegidsen uit de toolbox-wiki.",
+      "name": "internet",
+      "description": "Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
       "version": "0.1.4",
       "author": {
         "name": "developer-overheid-nl"
@@ -119,8 +119,8 @@
       ]
     },
     {
-      "name": "geonovum",
-      "description": "Plugin voor Geonovum geo-standaarden voor ruimtelijke data in Nederland. Bevat skills voor 6 domeinen: OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie, en 3D standaarden (CityGML, 3D Tiles).",
+      "name": "geo",
+      "description": "Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
       "version": "0.1.3",
       "author": {
         "name": "developer-overheid-nl"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-c
 claude plugin marketplace add developer-overheid-nl/skills-marketplace
 
 # 2. Installeer een plugin
-claude plugin install logius-standaarden@overheid-plugins
+claude plugin install standaarden@overheid-plugins
 ```
 
 ![Demo: plugin installeren en browsen](docs/demo.gif)
@@ -22,12 +22,12 @@ claude plugin install logius-standaarden@overheid-plugins
 
 | Plugin | Skills | Beschrijving | Maintainer |
 |--------|--------|-------------|------------|
-| [logius-standaarden](https://github.com/developer-overheid-nl/skills-standaarden) | 10 | Skills voor 77 Logius standaarden repositories: API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [standaarden](https://github.com/developer-overheid-nl/skills-standaarden) | 10 | Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, CloudEvents, BOMOS, en meer | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [zad-actions](https://github.com/RijksICTGilde/zad-actions) | 5 | Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en debugging | [Rijks ICT Gilde](https://github.com/RijksICTGilde) |
 | [developer-overheid](https://github.com/dstotijn/developer-overheid-nl-agent-skills) | 9 | Kennisbank van developer.overheid.nl: richtlijnen en standaarden voor overheidssoftwareontwikkeling (API's, data, frontend, infra, security, open source) | [David Stotijn](https://github.com/dstotijn) |
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
-| [internet-nl](https://github.com/developer-overheid-nl/skills-internet) | 5 | Skills voor internet.nl: test compliance met moderne internetstandaarden voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
-| [geonovum](https://github.com/developer-overheid-nl/skills-geo) | 6 | Skills voor Geonovum geo-standaarden: OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [internet](https://github.com/developer-overheid-nl/skills-internet) | 5 | Skills voor moderne internetstandaarden (getest via internet.nl): compliance voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
+| [geo](https://github.com/developer-overheid-nl/skills-geo) | 6 | Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [bio-security-baseline](https://github.com/MinBZK/bio-security-baseline-plugin) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen


### PR DESCRIPTION
Rename plugins to not imply org ownership:
- `logius-standaarden` → `standaarden`
- `internet-nl` → `internet`
- `geonovum` → `geo`

Descriptions still credit the source orgs (Logius, internet.nl, Geonovum) but the plugin names are now neutral.

Also updates standaarden version from 0.3.5 to 0.3.6 (linter.yml → linter.yaml fix).