### PR TITLE
Add cross-platform plugin marketplace (Claude Code + Cursor)

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "overheid-plugins",
   "metadata": {
-    "description": "Plugins voor de Nederlandse overheid"
+    "description": "Plugins voor de Nederlandse overheid",
+    "pluginRoot": ".cursor-plugin"
   },
   "owner": {
     "name": "developer-overheid-nl"
@@ -10,6 +10,7 @@
   "plugins": [
     {
       "name": "standaarden",
+      "displayName": "Standaarden",
       "description": "Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
       "version": "0.3.6",
       "author": {
@@ -19,8 +20,9 @@
         "source": "github",
         "repo": "developer-overheid-nl/skills-standaarden"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/developer-overheid-nl/skills-standaarden",
+      "keywords": [
+        "productivity",
         "overheid",
         "standaarden",
         "interoperabiliteit",
@@ -30,6 +32,7 @@
     },
     {
       "name": "zad-actions",
+      "displayName": "Zad Actions",
       "description": "Skills voor ZAD deployment: linting, releases, action validatie, workflow generatie en deployment debugging voor Zelfservice voor Applicatie Deployment.",
       "version": "1.2.0",
       "author": {
@@ -39,8 +42,9 @@
         "source": "github",
         "repo": "RijksICTGilde/zad-actions"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/RijksICTGilde/zad-actions",
+      "keywords": [
+        "productivity",
         "zad",
         "deployment",
         "github-actions",
@@ -52,6 +56,7 @@
     },
     {
       "name": "developer-overheid",
+      "displayName": "Developer Overheid",
       "description": "Dutch Government Developer Knowledge Base (developer.overheid.nl/kennisbank) - guidelines and standards for government software development",
       "version": "0.1.0",
       "author": {
@@ -61,8 +66,9 @@
         "source": "github",
         "repo": "dstotijn/developer-overheid-nl-agent-skills"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/dstotijn/developer-overheid-nl-agent-skills",
+      "keywords": [
+        "productivity",
         "overheid",
         "developer",
         "api",
@@ -74,6 +80,7 @@
     },
     {
       "name": "nerds",
+      "displayName": "Nerds",
       "description": "Plugin voor de Nederlandse Richtlijn Digitale Systemen (NeRDS). Bevat skills voor 13 richtlijnen die richting geven aan het ontwerpen, ontwikkelen en inkopen van digitale systemen binnen de Nederlandse overheid: gebruikersbehoeften, toegankelijkheid, open source, open standaarden, cloud, veiligheid, privacy, samenwerking, integratie, data, algoritmen, inkoop en duurzaamheid.",
       "version": "0.1.1",
       "author": {
@@ -83,8 +90,9 @@
         "source": "github",
         "repo": "MinBZK/NeRDS"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/MinBZK/NeRDS",
+      "keywords": [
+        "productivity",
         "overheid",
         "richtlijnen",
         "nerds",
@@ -98,6 +106,7 @@
     },
     {
       "name": "internet",
+      "displayName": "Internet",
       "description": "Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
       "version": "0.1.4",
       "author": {
@@ -107,8 +116,9 @@
         "source": "github",
         "repo": "developer-overheid-nl/skills-internet"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/developer-overheid-nl/skills-internet",
+      "keywords": [
+        "productivity",
         "overheid",
         "internet-standaarden",
         "compliance",
@@ -120,6 +130,7 @@
     },
     {
       "name": "geo",
+      "displayName": "Geo",
       "description": "Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
       "version": "0.1.3",
       "author": {
@@ -129,8 +140,9 @@
         "source": "github",
         "repo": "developer-overheid-nl/skills-geo"
       },
-      "category": "productivity",
-      "tags": [
+      "repository": "https://github.com/developer-overheid-nl/skills-geo",
+      "keywords": [
+        "productivity",
         "overheid",
         "geo",
         "geostandaarden",
@@ -142,6 +154,7 @@
     },
     {
       "name": "bio-security-baseline",
+      "displayName": "Bio Security Baseline",
       "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
       "version": "0.2.0",
       "author": {
@@ -151,8 +164,9 @@
         "source": "github",
         "repo": "MinBZK/bio-security-baseline-plugin"
       },
-      "category": "security",
-      "tags": [
+      "repository": "https://github.com/MinBZK/bio-security-baseline-plugin",
+      "keywords": [
+        "security",
         "overheid",
         "beveiliging",
         "informatiebeveiliging",

--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -18,7 +18,7 @@ import re
 import subprocess
 import sys
 
-MARKETPLACE_PATH = ".claude-plugin/marketplace.json"
+MARKETPLACE_PATH = "marketplace.json"
 
 SUBPROCESS_TIMEOUT = 60
 
@@ -347,6 +347,19 @@ def build_pr_body(updates: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def regenerate_platform_files() -> list[str]:
+    """Regenerate platform-specific marketplace files from the root.
+
+    Returns list of generated file paths (relative).
+    """
+    from generate_marketplace import generate_all, load_source, PLATFORMS
+
+    source_data = load_source()
+    generate_all(source_data)
+    return [str(path.relative_to(path.parent.parent.parent))
+            for _, (path, _) in PLATFORMS.items()]
+
+
 def create_pr(
     marketplace_path: str,
     data: dict,
@@ -365,6 +378,9 @@ def create_pr(
     with open(marketplace_path) as f:
         json.load(f)
 
+    # Regenerate platform-specific files
+    platform_files = regenerate_platform_files()
+
     # Git configuration and branch setup — fail fast with clear messages
     git_steps = [
         (["git", "config", "user.name", "github-actions[bot]"], "git config user.name"),
@@ -378,7 +394,7 @@ def create_pr(
             "git config user.email",
         ),
         (["git", "checkout", "-b", branch], "git checkout -b"),
-        (["git", "add", marketplace_path], "git add"),
+        (["git", "add", marketplace_path] + platform_files, "git add"),
     ]
     for cmd, label in git_steps:
         r = subprocess.run(

--- a/.github/scripts/generate_marketplace.py
+++ b/.github/scripts/generate_marketplace.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate platform-specific marketplace files from the neutral root format.
+
+The root marketplace.json is the single source of truth. This script generates
+platform-specific variants for Claude Code and Cursor (and future platforms).
+
+Usage:
+    python generate_marketplace.py          # generate all platform files
+    python generate_marketplace.py --check  # verify files are in sync
+"""
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent
+SOURCE_PATH = ROOT_DIR / "marketplace.json"
+CLAUDE_PATH = ROOT_DIR / ".claude-plugin" / "marketplace.json"
+CURSOR_PATH = ROOT_DIR / ".cursor-plugin" / "marketplace.json"
+
+CLAUDE_SCHEMA = "https://anthropic.com/claude-code/marketplace.schema.json"
+
+
+def load_source() -> dict:
+    """Load the neutral marketplace.json from the project root."""
+    with open(SOURCE_PATH) as f:
+        return json.load(f)
+
+
+def generate_claude(data: dict) -> dict:
+    """Generate Claude Code marketplace.json.
+
+    Adds $schema and copies all fields unchanged.
+    """
+    result = {"$schema": CLAUDE_SCHEMA}
+    result.update(copy.deepcopy(data))
+    return result
+
+
+def _display_name(name: str) -> str:
+    """Convert a kebab-case plugin name to a human-readable display name.
+
+    Examples:
+        "standaarden" -> "Standaarden"
+        "zad-actions" -> "Zad Actions"
+        "bio-security-baseline" -> "Bio Security Baseline"
+    """
+    return name.replace("-", " ").title()
+
+
+def _transform_plugin_for_cursor(plugin: dict) -> dict:
+    """Transform a single plugin entry to Cursor format."""
+    cursor_plugin: dict = {
+        "name": plugin["name"],
+        "displayName": _display_name(plugin["name"]),
+    }
+
+    if "description" in plugin:
+        cursor_plugin["description"] = plugin["description"]
+    if "version" in plugin:
+        cursor_plugin["version"] = plugin["version"]
+    if "author" in plugin:
+        cursor_plugin["author"] = copy.deepcopy(plugin["author"])
+
+    # Source mapping
+    source = plugin.get("source", {})
+    if isinstance(source, dict):
+        cursor_plugin["source"] = copy.deepcopy(source)
+        if source.get("source") == "github":
+            repo = source.get("repo", "")
+            cursor_plugin["repository"] = f"https://github.com/{repo}"
+
+    # Keywords: merge category + tags
+    keywords = []
+    if "category" in plugin:
+        keywords.append(plugin["category"])
+    keywords.extend(plugin.get("tags", []))
+    if keywords:
+        cursor_plugin["keywords"] = keywords
+
+    return cursor_plugin
+
+
+def generate_cursor(data: dict) -> dict:
+    """Generate Cursor marketplace.json.
+
+    Transforms plugin fields to Cursor's expected format.
+    """
+    result: dict = {
+        "name": data.get("name", ""),
+        "metadata": {
+            "description": data.get("metadata", {}).get("description", ""),
+            "pluginRoot": ".cursor-plugin",
+        },
+        "owner": copy.deepcopy(data.get("owner", {})),
+        "plugins": [
+            _transform_plugin_for_cursor(p) for p in data.get("plugins", [])
+        ],
+    }
+    return result
+
+
+# Registry of platform generators — add new platforms here
+PLATFORMS: dict[str, tuple[Path, callable]] = {
+    "claude": (CLAUDE_PATH, generate_claude),
+    "cursor": (CURSOR_PATH, generate_cursor),
+}
+
+
+def write_json(path: Path, data: dict) -> None:
+    """Write JSON data to a file with consistent formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def generate_all(source_data: dict) -> dict[str, dict]:
+    """Generate all platform marketplace files. Returns dict of platform -> data."""
+    results = {}
+    for name, (path, generator) in PLATFORMS.items():
+        generated = generator(source_data)
+        write_json(path, generated)
+        results[name] = generated
+        print(f"Gegenereerd: {path.relative_to(ROOT_DIR)}")
+    return results
+
+
+def check_sync(source_data: dict) -> bool:
+    """Check if platform files are in sync with the source. Returns True if synced."""
+    all_synced = True
+
+    for name, (path, generator) in PLATFORMS.items():
+        expected = generator(source_data)
+
+        if not path.exists():
+            print(f"FOUT: {path.relative_to(ROOT_DIR)} bestaat niet")
+            all_synced = False
+            continue
+
+        with open(path) as f:
+            actual = json.load(f)
+
+        if actual != expected:
+            print(f"FOUT: {path.relative_to(ROOT_DIR)} is niet in sync met marketplace.json")
+            all_synced = False
+        else:
+            print(f"OK: {path.relative_to(ROOT_DIR)} is in sync")
+
+    return all_synced
+
+
+def main() -> None:
+    if not SOURCE_PATH.exists():
+        print(f"FOUT: {SOURCE_PATH} niet gevonden")
+        sys.exit(1)
+
+    source_data = load_source()
+
+    if "--check" in sys.argv:
+        if check_sync(source_data):
+            print("\nAlle platform-bestanden zijn in sync")
+            sys.exit(0)
+        else:
+            print("\nPlatform-bestanden zijn NIET in sync. Draai: python generate_marketplace.py")
+            sys.exit(1)
+    else:
+        generate_all(source_data)
+        print("\nAlle platform-bestanden gegenereerd")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate_marketplace.py
+++ b/.github/scripts/generate_marketplace.py
@@ -131,7 +131,7 @@ def check_sync(source_data: dict) -> bool:
     """Check if platform files are in sync with the source. Returns True if synced."""
     all_synced = True
 
-    for name, (path, generator) in PLATFORMS.items():
+    for _name, (path, generator) in PLATFORMS.items():
         expected = generator(source_data)
 
         if not path.exists():

--- a/.github/scripts/test_check_versions.py
+++ b/.github/scripts/test_check_versions.py
@@ -18,6 +18,7 @@ from check_versions import (
     fetch_upstream_plugin,
     main,
     normalize_version,
+    regenerate_platform_files,
     resolve_repo,
     sanitize_branch,
     validate_repo,
@@ -630,7 +631,17 @@ class TestWriteJobSummary:
         assert "\u26a0\ufe0f" in summary_file.read_text()
 
 
+MOCK_PLATFORM_FILES = [".claude-plugin/marketplace.json", ".cursor-plugin/marketplace.json"]
+
+
 class TestCreatePr:
+    @pytest.fixture(autouse=True)
+    def _mock_regenerate(self, monkeypatch):
+        monkeypatch.setattr(
+            "check_versions.regenerate_platform_files",
+            lambda: MOCK_PLATFORM_FILES,
+        )
+
     @patch("check_versions.subprocess.run")
     def test_success(self, mock_run, tmp_path):
         marketplace = tmp_path / "marketplace.json"

--- a/.github/scripts/test_generate_marketplace.py
+++ b/.github/scripts/test_generate_marketplace.py
@@ -1,0 +1,271 @@
+"""Tests for generate_marketplace.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from generate_marketplace import (
+    CLAUDE_SCHEMA,
+    _display_name,
+    _transform_plugin_for_cursor,
+    check_sync,
+    generate_all,
+    generate_claude,
+    generate_cursor,
+    load_source,
+    write_json,
+)
+
+SAMPLE_DATA = {
+    "name": "test-plugins",
+    "metadata": {"description": "Test plugins"},
+    "owner": {"name": "test-org"},
+    "plugins": [
+        {
+            "name": "my-plugin",
+            "description": "A test plugin",
+            "version": "1.0.0",
+            "author": {"name": "Test Author"},
+            "source": {"source": "github", "repo": "org/my-plugin"},
+            "category": "productivity",
+            "tags": ["test", "demo"],
+        }
+    ],
+}
+
+SAMPLE_PLUGIN = SAMPLE_DATA["plugins"][0]
+
+
+class TestDisplayName:
+    def test_single_word(self):
+        assert _display_name("standaarden") == "Standaarden"
+
+    def test_hyphenated(self):
+        assert _display_name("zad-actions") == "Zad Actions"
+
+    def test_multi_hyphen(self):
+        assert _display_name("bio-security-baseline") == "Bio Security Baseline"
+
+    def test_already_capitalized(self):
+        assert _display_name("MyPlugin") == "Myplugin"
+
+
+class TestGenerateClaude:
+    def test_adds_schema(self):
+        result = generate_claude(SAMPLE_DATA)
+        assert result["$schema"] == CLAUDE_SCHEMA
+
+    def test_preserves_all_fields(self):
+        result = generate_claude(SAMPLE_DATA)
+        assert result["name"] == "test-plugins"
+        assert result["owner"] == {"name": "test-org"}
+        assert len(result["plugins"]) == 1
+        assert result["plugins"][0]["name"] == "my-plugin"
+
+    def test_schema_is_first_key(self):
+        result = generate_claude(SAMPLE_DATA)
+        keys = list(result.keys())
+        assert keys[0] == "$schema"
+
+    def test_deep_copy(self):
+        result = generate_claude(SAMPLE_DATA)
+        result["plugins"][0]["name"] = "modified"
+        assert SAMPLE_DATA["plugins"][0]["name"] == "my-plugin"
+
+
+class TestTransformPluginForCursor:
+    def test_display_name(self):
+        result = _transform_plugin_for_cursor(SAMPLE_PLUGIN)
+        assert result["displayName"] == "My Plugin"
+
+    def test_keywords_from_category_and_tags(self):
+        result = _transform_plugin_for_cursor(SAMPLE_PLUGIN)
+        assert result["keywords"] == ["productivity", "test", "demo"]
+
+    def test_repository_url(self):
+        result = _transform_plugin_for_cursor(SAMPLE_PLUGIN)
+        assert result["repository"] == "https://github.com/org/my-plugin"
+
+    def test_preserves_basic_fields(self):
+        result = _transform_plugin_for_cursor(SAMPLE_PLUGIN)
+        assert result["name"] == "my-plugin"
+        assert result["description"] == "A test plugin"
+        assert result["version"] == "1.0.0"
+        assert result["author"] == {"name": "Test Author"}
+
+    def test_no_category_no_tags(self):
+        plugin = {"name": "bare", "source": {"source": "github", "repo": "o/r"}}
+        result = _transform_plugin_for_cursor(plugin)
+        assert "keywords" not in result
+
+    def test_only_category(self):
+        plugin = {
+            "name": "cat-only",
+            "category": "security",
+            "source": {"source": "github", "repo": "o/r"},
+        }
+        result = _transform_plugin_for_cursor(plugin)
+        assert result["keywords"] == ["security"]
+
+    def test_only_tags(self):
+        plugin = {
+            "name": "tags-only",
+            "tags": ["a", "b"],
+            "source": {"source": "github", "repo": "o/r"},
+        }
+        result = _transform_plugin_for_cursor(plugin)
+        assert result["keywords"] == ["a", "b"]
+
+    def test_non_github_source(self):
+        plugin = {
+            "name": "other",
+            "source": {"source": "url", "url": "https://example.com"},
+        }
+        result = _transform_plugin_for_cursor(plugin)
+        assert "repository" not in result
+
+    def test_deep_copy_author(self):
+        result = _transform_plugin_for_cursor(SAMPLE_PLUGIN)
+        result["author"]["name"] = "modified"
+        assert SAMPLE_PLUGIN["author"]["name"] == "Test Author"
+
+
+class TestGenerateCursor:
+    def test_structure(self):
+        result = generate_cursor(SAMPLE_DATA)
+        assert result["name"] == "test-plugins"
+        assert result["metadata"]["pluginRoot"] == ".cursor-plugin"
+        assert result["owner"] == {"name": "test-org"}
+        assert len(result["plugins"]) == 1
+
+    def test_no_schema(self):
+        result = generate_cursor(SAMPLE_DATA)
+        assert "$schema" not in result
+
+    def test_plugin_transformed(self):
+        result = generate_cursor(SAMPLE_DATA)
+        plugin = result["plugins"][0]
+        assert "displayName" in plugin
+        assert "keywords" in plugin
+
+
+class TestWriteJson:
+    def test_writes_valid_json(self, tmp_path):
+        path = tmp_path / "sub" / "test.json"
+        write_json(path, {"key": "value"})
+        with open(path) as f:
+            data = json.load(f)
+        assert data == {"key": "value"}
+
+    def test_trailing_newline(self, tmp_path):
+        path = tmp_path / "test.json"
+        write_json(path, {})
+        assert path.read_text().endswith("\n")
+
+    def test_creates_parent_dirs(self, tmp_path):
+        path = tmp_path / "a" / "b" / "test.json"
+        write_json(path, {})
+        assert path.exists()
+
+    def test_unicode(self, tmp_path):
+        path = tmp_path / "test.json"
+        write_json(path, {"text": "Digikoppeling — standaard"})
+        content = path.read_text()
+        assert "Digikoppeling — standaard" in content
+
+
+class TestCheckSync:
+    def test_in_sync(self, tmp_path):
+        source = SAMPLE_DATA
+
+        with patch("generate_marketplace.PLATFORMS") as mock_platforms, \
+             patch("generate_marketplace.ROOT_DIR", tmp_path):
+            claude_path = tmp_path / ".claude-plugin" / "marketplace.json"
+            generated = generate_claude(source)
+            write_json(claude_path, generated)
+            mock_platforms.items.return_value = [
+                ("claude", (claude_path, generate_claude))
+            ]
+
+            assert check_sync(source) is True
+
+    def test_out_of_sync(self, tmp_path):
+        source = SAMPLE_DATA
+
+        with patch("generate_marketplace.PLATFORMS") as mock_platforms, \
+             patch("generate_marketplace.ROOT_DIR", tmp_path):
+            claude_path = tmp_path / ".claude-plugin" / "marketplace.json"
+            write_json(claude_path, {"different": "data"})
+            mock_platforms.items.return_value = [
+                ("claude", (claude_path, generate_claude))
+            ]
+
+            assert check_sync(source) is False
+
+    def test_missing_file(self, tmp_path):
+        source = SAMPLE_DATA
+
+        with patch("generate_marketplace.PLATFORMS") as mock_platforms, \
+             patch("generate_marketplace.ROOT_DIR", tmp_path):
+            missing_path = tmp_path / "nonexistent" / "marketplace.json"
+            mock_platforms.items.return_value = [
+                ("claude", (missing_path, generate_claude))
+            ]
+
+            assert check_sync(source) is False
+
+
+class TestGenerateAll:
+    def test_generates_both_files(self, tmp_path):
+        source = SAMPLE_DATA
+        claude_path = tmp_path / ".claude-plugin" / "marketplace.json"
+        cursor_path = tmp_path / ".cursor-plugin" / "marketplace.json"
+
+        with patch("generate_marketplace.PLATFORMS", {
+            "claude": (claude_path, generate_claude),
+            "cursor": (cursor_path, generate_cursor),
+        }), patch("generate_marketplace.ROOT_DIR", tmp_path):
+            results = generate_all(source)
+
+        assert claude_path.exists()
+        assert cursor_path.exists()
+        assert "claude" in results
+        assert "cursor" in results
+
+        with open(claude_path) as f:
+            claude_data = json.load(f)
+        assert claude_data["$schema"] == CLAUDE_SCHEMA
+
+        with open(cursor_path) as f:
+            cursor_data = json.load(f)
+        assert cursor_data["metadata"]["pluginRoot"] == ".cursor-plugin"
+
+
+class TestEndToEnd:
+    """Test with the real marketplace.json in the repo."""
+
+    def test_real_marketplace(self):
+        """Verify the generation script works with the actual marketplace.json."""
+        source_path = Path(__file__).resolve().parent.parent.parent / "marketplace.json"
+        if not source_path.exists():
+            pytest.skip("marketplace.json not found in repo root")
+
+        with open(source_path) as f:
+            source = json.load(f)
+
+        # Generate Claude
+        claude = generate_claude(source)
+        assert "$schema" in claude
+        assert len(claude["plugins"]) == len(source["plugins"])
+
+        # Generate Cursor
+        cursor = generate_cursor(source)
+        assert cursor["metadata"]["pluginRoot"] == ".cursor-plugin"
+        assert len(cursor["plugins"]) == len(source["plugins"])
+
+        # Every Cursor plugin should have displayName and source
+        for plugin in cursor["plugins"]:
+            assert "displayName" in plugin
+            assert "source" in plugin

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,14 +14,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Valideer marketplace.json syntax
-        run: python3 -c "import json; json.load(open('.claude-plugin/marketplace.json'))"
+        run: python3 -c "import json; json.load(open('marketplace.json'))"
 
       - name: Valideer marketplace structuur
         run: |
           python3 << 'SCRIPT'
           import json, sys
 
-          with open('.claude-plugin/marketplace.json') as f:
+          with open('marketplace.json') as f:
               data = json.load(f)
 
           errors = []
@@ -55,6 +55,41 @@ jobs:
           print(f"Marketplace '{data['name']}' is geldig ({len(data['plugins'])} plugins)")
           SCRIPT
 
+      - name: Controleer platform-bestanden in sync
+        run: python3 .github/scripts/generate_marketplace.py --check
+
+      - name: Valideer Cursor marketplace structuur
+        run: |
+          python3 << 'SCRIPT'
+          import json, sys
+
+          with open('.cursor-plugin/marketplace.json') as f:
+              data = json.load(f)
+
+          errors = []
+
+          for field in ['name', 'owner', 'plugins']:
+              if field not in data:
+                  errors.append(f"Verplicht veld '{field}' ontbreekt")
+
+          if 'metadata' in data and 'pluginRoot' not in data.get('metadata', {}):
+              errors.append("Verplicht veld 'metadata.pluginRoot' ontbreekt")
+
+          for i, plugin in enumerate(data.get('plugins', [])):
+              prefix = f"plugins[{i}]"
+              if 'displayName' not in plugin:
+                  errors.append(f"{prefix}: 'displayName' ontbreekt")
+              if 'source' not in plugin:
+                  errors.append(f"{prefix}: 'source' ontbreekt")
+
+          if errors:
+              for e in errors:
+                  print(f"FOUT: {e}")
+              sys.exit(1)
+
+          print(f"Cursor marketplace is geldig ({len(data['plugins'])} plugins)")
+          SCRIPT
+
       - name: Controleer plugin-repos bereikbaar
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +97,7 @@ jobs:
           python3 << 'SCRIPT'
           import json, subprocess, sys
 
-          with open('.claude-plugin/marketplace.json') as f:
+          with open('marketplace.json') as f:
               data = json.load(f)
 
           errors = []
@@ -108,7 +143,7 @@ jobs:
           python3 << 'SCRIPT'
           import json, subprocess, sys
 
-          with open('.claude-plugin/marketplace.json') as f:
+          with open('marketplace.json') as f:
               data = json.load(f)
 
           errors = []
@@ -153,7 +188,7 @@ jobs:
 
       - name: Controleer vereiste bestanden
         run: |
-          for f in LICENSE README.md CONTRIBUTING.md CHANGELOG.md .claude-plugin/marketplace.json; do
+          for f in LICENSE README.md CONTRIBUTING.md CHANGELOG.md marketplace.json .claude-plugin/marketplace.json .cursor-plugin/marketplace.json; do
             if [ ! -f "$f" ]; then
               echo "FOUT: $f ontbreekt"
               exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,9 @@ Open een [Plugin aanmelding](../../issues/new?template=plugin-aanmelding.yml) is
 ### 2. Via een pull request
 
 1. Fork deze repository
-2. Voeg je plugin toe aan `.claude-plugin/marketplace.json`
-3. Open een pull request met een beschrijving van je plugin
+2. Voeg je plugin toe aan `marketplace.json` (in de root)
+3. Draai `python .github/scripts/generate_marketplace.py` om platform-bestanden te genereren
+4. Open een pull request met een beschrijving van je plugin
 
 Zie [docs/plugin-toevoegen.md](docs/plugin-toevoegen.md) voor gedetailleerde instructies.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Overheid Claude Plugins
+# Overheid AI-Assistant Plugins
 
 [![EUPL-1.2](https://img.shields.io/badge/licentie-EUPL--1.2-blue.svg)](LICENSE)
 [![plugins](https://img.shields.io/badge/plugins-7-green.svg)](#beschikbare-plugins)
 [![CI](https://github.com/developer-overheid-nl/skills-marketplace/actions/workflows/validate.yml/badge.svg)](https://github.com/developer-overheid-nl/skills-marketplace/actions/workflows/validate.yml)
 
-Centrale catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins voor de Nederlandse overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins publiceren en ontdekken.
+Centrale catalogus van AI-assistant plugins voor de Nederlandse overheid. Ondersteunt meerdere platformen: [Claude Code](https://docs.anthropic.com/en/docs/claude-code) en [Cursor](https://www.cursor.com/). Via deze marketplace kunnen overheidsteams hun plugins publiceren en ontdekken.
 
 ## Snel starten
 
@@ -50,12 +50,31 @@ Zie [CONTRIBUTING.md](CONTRIBUTING.md) voor het volledige review-proces.
 ## Structuur
 
 ```
+marketplace.json              # Neutraal formaat (single source of truth)
 .claude-plugin/
-  marketplace.json      # Catalogus met alle plugins
+  marketplace.json            # Gegenereerd voor Claude Code
+.cursor-plugin/
+  marketplace.json            # Gegenereerd voor Cursor
+.github/scripts/
+  generate_marketplace.py     # Genereert platform-bestanden
 docs/
-  plugin-maken.md       # Handleiding: plugin bouwen
-  plugin-toevoegen.md   # Handleiding: plugin registreren
+  plugin-maken.md             # Handleiding: plugin bouwen
+  plugin-toevoegen.md         # Handleiding: plugin registreren
 ```
+
+### Cross-platform architectuur
+
+Het neutrale `marketplace.json` in de root is de single source of truth. Platform-specifieke bestanden worden gegenereerd door `generate_marketplace.py`. CI controleert of de gegenereerde bestanden in sync zijn.
+
+```bash
+# Genereer platform-bestanden
+uv run python .github/scripts/generate_marketplace.py
+
+# Controleer of alles in sync is
+uv run python .github/scripts/generate_marketplace.py --check
+```
+
+Een nieuw platform toevoegen (bijv. Windsurf, Copilot) vereist alleen een nieuwe `generate_<platform>()` functie in het script.
 
 ## Disclaimer
 

--- a/docs/plugin-maken.md
+++ b/docs/plugin-maken.md
@@ -111,6 +111,13 @@ Heb je al `.claude/skills/` in je project? Je kunt ze **in-place** omzetten naar
 
 Zo heb je **één locatie** voor skills die zowel lokaal in het project als via de marketplace werkt. Zie [zad-actions](https://github.com/RijksICTGilde/zad-actions) voor een werkend voorbeeld.
 
+## Cursor compatibiliteit
+
+`SKILL.md` bestanden met YAML frontmatter zijn cross-platform en werken in zowel Claude Code als Cursor. Om je plugin ook via Cursor beschikbaar te maken:
+
+1. Voeg `.cursor-plugin/plugin.json` toe aan je repository (vergelijkbaar met `.claude-plugin/plugin.json`)
+2. De marketplace genereert automatisch een Cursor-variant met `displayName`, `keywords` en `repository` velden
+
 ## Meer informatie
 
 - [Claude Code plugin documentatie](https://code.claude.com/docs/en/plugins)

--- a/docs/plugin-toevoegen.md
+++ b/docs/plugin-toevoegen.md
@@ -29,7 +29,7 @@ cd skills-marketplace
 
 ### Stap 2: Voeg je plugin toe aan marketplace.json
 
-Open `.claude-plugin/marketplace.json` en voeg je plugin toe aan de `plugins` array:
+Open `marketplace.json` (in de root van het project) en voeg je plugin toe aan de `plugins` array:
 
 ```json
 {
@@ -65,7 +65,9 @@ Open `.claude-plugin/marketplace.json` en voeg je plugin toe aan de `plugins` ar
 
 ```bash
 git checkout -b add-jouw-plugin
-git add .claude-plugin/marketplace.json
+# Genereer platform-bestanden na het wijzigen van marketplace.json
+python .github/scripts/generate_marketplace.py
+git add marketplace.json .claude-plugin/marketplace.json .cursor-plugin/marketplace.json
 git commit -m "Voeg jouw-plugin toe aan marketplace"
 git push origin add-jouw-plugin
 gh pr create --title "Voeg jouw-plugin toe" --body "Beschrijving van de plugin en wat deze doet."
@@ -91,5 +93,6 @@ claude plugin install jouw-plugin@overheid-plugins
 Als je een nieuwe versie van je plugin uitbrengt:
 
 1. Update de `version` in je eigen `plugin.json`
-2. Open een PR om de `version` in `marketplace.json` bij te werken
-3. Gebruikers krijgen de update via `claude plugin marketplace update`
+2. Open een PR om de `version` in `marketplace.json` (root) bij te werken
+3. Draai `python .github/scripts/generate_marketplace.py` om de platform-bestanden bij te werken
+4. Gebruikers krijgen de update via `claude plugin marketplace update`

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "overheid-plugins",
   "metadata": {
     "description": "Plugins voor de Nederlandse overheid"


### PR DESCRIPTION
## Summary

- Introduce a neutral `marketplace.json` (root) as single source of truth for all platforms
- Add `generate_marketplace.py` that generates platform-specific files for Claude Code (`.claude-plugin/`) and Cursor (`.cursor-plugin/`)
- Add CI sync check to ensure generated files stay in sync with root
- Update `check_versions.py` to read from root and regenerate platform files on automated PRs
- Update documentation (README, CONTRIBUTING, docs/) to reflect the new cross-platform architecture

## Context

Cursor recently added plugin marketplace support with an architecture similar to Claude Code. This PR establishes a neutral format as a "concept overheidsstandaard" for AI-assistant plugins, making it easy to add new platforms (Windsurf, Copilot, etc.) by adding a single generator function.

Architecture:
```
marketplace.json  (root, neutral, hand-edited)
       ├──▶ .claude-plugin/marketplace.json  (generated, adds $schema)
       └──▶ .cursor-plugin/marketplace.json  (generated, adds displayName, keywords, repository)
```

## Test plan

- [x] `uv run pytest .github/scripts/test_generate_marketplace.py` — 29 tests pass
- [x] `uv run pytest .github/scripts/test_check_versions.py` — 90 tests pass
- [x] `uv run python .github/scripts/generate_marketplace.py --check` — sync check passes
- [x] `.claude-plugin/marketplace.json` contains `$schema` and all 7 plugins
- [x] `.cursor-plugin/marketplace.json` contains `displayName`, `keywords`, `repository` per plugin
- [ ] CI workflow passes on this PR