### PR TITLE
Check all platform files in upstream repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin-aanmelding.yml
+++ b/.github/ISSUE_TEMPLATE/plugin-aanmelding.yml
@@ -1,5 +1,5 @@
 name: Plugin aanmelding
-description: Meld een nieuwe Claude Code plugin aan voor de marketplace
+description: Meld een nieuwe plugin aan voor de marketplace
 title: "[Plugin] "
 labels: ["plugin-aanmelding"]
 body:
@@ -79,7 +79,7 @@ body:
       options:
         - label: De repository is publiek toegankelijk
           required: true
-        - label: Er is een geldige `.claude-plugin/plugin.json` aanwezig
+        - label: Er is een geldige `.plugin/plugin.json` aanwezig (met gegenereerde platform-bestanden)
           required: true
         - label: De plugin bevat minimaal 1 werkende skill, command of agent
           required: true

--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -97,8 +97,8 @@ def resolve_repo(plugin: dict) -> str | None:
     return None
 
 
-def fetch_upstream_plugin(repo: str) -> dict | None:
-    """Fetch and parse the upstream plugin.json from a GitHub repo.
+def _fetch_json_from_repo(repo: str, path: str) -> dict | None:
+    """Fetch and parse a JSON file from a GitHub repo via the API.
 
     Returns parsed dict or None on failure (including timeout).
     """
@@ -107,7 +107,7 @@ def fetch_upstream_plugin(repo: str) -> dict | None:
             [
                 "gh",
                 "api",
-                f"repos/{repo}/contents/.claude-plugin/plugin.json",
+                f"repos/{repo}/contents/{path}",
                 "--jq",
                 ".content",
             ],
@@ -116,7 +116,7 @@ def fetch_upstream_plugin(repo: str) -> dict | None:
             timeout=SUBPROCESS_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        print(f"WAARSCHUWING: timeout bij ophalen plugin.json uit {repo}")
+        print(f"WAARSCHUWING: timeout bij ophalen {path} uit {repo}")
         return None
     if result.returncode != 0:
         return None
@@ -126,6 +126,18 @@ def fetch_upstream_plugin(repo: str) -> dict | None:
         return json.loads(content)
     except (json.JSONDecodeError, ValueError, binascii.Error):
         return None
+
+
+def fetch_upstream_plugin(repo: str) -> dict | None:
+    """Fetch and parse the upstream plugin.json from a GitHub repo.
+
+    Tries .plugin/plugin.json first (source of truth), falls back to
+    .claude-plugin/plugin.json for repos that haven't migrated yet.
+    """
+    result = _fetch_json_from_repo(repo, ".plugin/plugin.json")
+    if result is not None:
+        return result
+    return _fetch_json_from_repo(repo, ".claude-plugin/plugin.json")
 
 
 def detect_updates(

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -136,7 +136,7 @@ jobs:
           print("Alle bereikbare plugin-repos gecontroleerd")
           SCRIPT
 
-      - name: Controleer plugin.json aanwezig in repos
+      - name: Controleer platform-bestanden aanwezig in repos
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -145,6 +145,12 @@ jobs:
 
           with open('marketplace.json') as f:
               data = json.load(f)
+
+          REQUIRED_PATHS = [
+              '.plugin/plugin.json',
+              '.claude-plugin/plugin.json',
+              '.cursor-plugin/plugin.json',
+          ]
 
           errors = []
           for plugin in data.get('plugins', []):
@@ -169,21 +175,26 @@ jobs:
                   print(f"SKIP: {plugin['name']} -> '{repo}' niet bereikbaar (mogelijk private repo)")
                   continue
 
-              result = subprocess.run(
-                  ['gh', 'api', f'repos/{repo}/contents/.claude-plugin/plugin.json', '--jq', '.name'],
-                  capture_output=True, text=True
-              )
-              if result.returncode != 0:
-                  errors.append(f"{plugin['name']}: .claude-plugin/plugin.json niet gevonden in {repo}")
+              missing = []
+              for path in REQUIRED_PATHS:
+                  result = subprocess.run(
+                      ['gh', 'api', f'repos/{repo}/contents/{path}', '--jq', '.name'],
+                      capture_output=True, text=True
+                  )
+                  if result.returncode != 0:
+                      missing.append(path)
+
+              if missing:
+                  errors.append(f"{plugin['name']}: ontbreekt in {repo}: {', '.join(missing)}")
               else:
-                  print(f"OK: {plugin['name']} heeft plugin.json")
+                  print(f"OK: {plugin['name']} heeft alle platform-bestanden")
 
           if errors:
               for e in errors:
                   print(f"FOUT: {e}")
               sys.exit(1)
 
-          print("Alle bereikbare plugins hebben een geldig manifest")
+          print("Alle bereikbare plugins hebben alle platform-bestanden")
           SCRIPT
 
       - name: Controleer vereiste bestanden

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -146,13 +146,12 @@ jobs:
           with open('marketplace.json') as f:
               data = json.load(f)
 
-          REQUIRED_PATHS = [
-              '.plugin/plugin.json',
-              '.claude-plugin/plugin.json',
-              '.cursor-plugin/plugin.json',
-          ]
+          # .claude-plugin is verplicht, .plugin en .cursor-plugin zijn gewenst
+          REQUIRED_PATHS = ['.claude-plugin/plugin.json']
+          DESIRED_PATHS = ['.plugin/plugin.json', '.cursor-plugin/plugin.json']
 
           errors = []
+          warnings = []
           for plugin in data.get('plugins', []):
               source = plugin.get('source', {})
               if isinstance(source, dict) and source.get('source') == 'github':
@@ -175,26 +174,41 @@ jobs:
                   print(f"SKIP: {plugin['name']} -> '{repo}' niet bereikbaar (mogelijk private repo)")
                   continue
 
-              missing = []
+              missing_required = []
               for path in REQUIRED_PATHS:
                   result = subprocess.run(
                       ['gh', 'api', f'repos/{repo}/contents/{path}', '--jq', '.name'],
                       capture_output=True, text=True
                   )
                   if result.returncode != 0:
-                      missing.append(path)
+                      missing_required.append(path)
 
-              if missing:
-                  errors.append(f"{plugin['name']}: ontbreekt in {repo}: {', '.join(missing)}")
+              missing_desired = []
+              for path in DESIRED_PATHS:
+                  result = subprocess.run(
+                      ['gh', 'api', f'repos/{repo}/contents/{path}', '--jq', '.name'],
+                      capture_output=True, text=True
+                  )
+                  if result.returncode != 0:
+                      missing_desired.append(path)
+
+              if missing_required:
+                  errors.append(f"{plugin['name']}: ontbreekt in {repo}: {', '.join(missing_required)}")
+              elif missing_desired:
+                  warnings.append(f"{plugin['name']}: ontbreekt in {repo}: {', '.join(missing_desired)}")
+                  print(f"WAARSCHUWING: {plugin['name']} mist: {', '.join(missing_desired)}")
               else:
                   print(f"OK: {plugin['name']} heeft alle platform-bestanden")
+
+          if warnings:
+              print(f"\n{len(warnings)} plugin(s) missen cross-platform bestanden")
 
           if errors:
               for e in errors:
                   print(f"FOUT: {e}")
               sys.exit(1)
 
-          print("Alle bereikbare plugins hebben alle platform-bestanden")
+          print("Alle bereikbare plugins hebben de verplichte bestanden")
           SCRIPT
 
       - name: Controleer vereiste bestanden

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ en dit project volgt [Semantic Versioning](https://semver.org/lang/nl/).
 
 ### Toegevoegd
 
-- Marketplace opgezet als centrale catalogus voor overheids-Claude Code plugins
+- Marketplace opgezet als centrale catalogus voor overheids AI-assistant plugins
 - Plugin: logius-standaarden v1.0.0 (10 skills voor 88 Logius standaarden repositories)
 - Plugin: zad-actions v1.0.0 (3 skills voor ZAD deployment)
 - Documentatie: plugin-maken.md handleiding

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,6 +1,6 @@
 # Disclaimer
 
-Deze marketplace is een **experimenteel project** om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de Nederlandse overheid. De marketplace biedt een catalogus van [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugins die worden ontwikkeld en onderhouden door verschillende teams en organisaties.
+Deze marketplace is een **experimenteel project** om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de Nederlandse overheid. De marketplace biedt een catalogus van AI-assistant plugins die worden ontwikkeld en onderhouden door verschillende teams en organisaties.
 
 ## De plugins in deze marketplace zijn niet de officiële standaarden
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ claude plugin install standaarden@overheid-plugins
 
 ## Plugin toevoegen
 
-Heb je een Claude Code plugin die relevant is voor de Nederlandse overheid? Voeg hem toe aan deze marketplace:
+Heb je een plugin die relevant is voor de Nederlandse overheid? Voeg hem toe aan deze marketplace:
 
 1. **Plugin bouwen** - Zie [docs/plugin-maken.md](docs/plugin-maken.md) voor een stap-voor-stap handleiding
 2. **Plugin aanmelden** - Zie [docs/plugin-toevoegen.md](docs/plugin-toevoegen.md) of open een [issue](../../issues/new?template=plugin-aanmelding.yml)
@@ -41,7 +41,7 @@ Heb je een Claude Code plugin die relevant is voor de Nederlandse overheid? Voeg
 
 - Open-source licentie (EUPL-1.2, Apache-2.0, MIT, of vergelijkbaar)
 - Publieke GitHub repository
-- Geldige `.claude-plugin/plugin.json`
+- Geldige `.plugin/plugin.json`
 - Minimaal 1 werkende skill, command of agent
 - Nederlandse of tweetalige documentatie
 

--- a/docs/plugin-maken.md
+++ b/docs/plugin-maken.md
@@ -1,10 +1,10 @@
-# Een Claude Code plugin maken
+# Een plugin maken
 
-Deze handleiding beschrijft hoe je een Claude Code plugin bouwt die via de marketplace gedistribueerd kan worden.
+Deze handleiding beschrijft hoe je een AI-assistant plugin bouwt die via de marketplace gedistribueerd kan worden.
 
 ## Wat is een plugin?
 
-Een Claude Code plugin is een verzameling skills, commands, agents, hooks en/of MCP servers die Claude Code uitbreiden met domeinkennis of tooling. Plugins worden gedistribueerd via een marketplace en zijn beschikbaar in elke Claude Code sessie.
+Een plugin is een verzameling skills, commands, agents, hooks en/of MCP servers die een AI-assistant uitbreiden met domeinkennis of tooling. Plugins worden gedistribueerd via een marketplace en werken in meerdere platformen (Claude Code, Cursor).
 
 ## Stap 1: Directory-structuur
 
@@ -12,8 +12,14 @@ Maak de volgende structuur aan in je repository:
 
 ```
 mijn-plugin/
+├── .plugin/
+│   └── plugin.json          # Plugin manifest, source of truth (verplicht)
 ├── .claude-plugin/
-│   └── plugin.json          # Plugin manifest (verplicht)
+│   └── plugin.json          # Gegenereerd voor Claude Code
+├── .cursor-plugin/
+│   └── plugin.json          # Gegenereerd voor Cursor
+├── scripts/
+│   └── generate_plugin.py   # Genereert platform-bestanden
 ├── skills/
 │   └── mijn-skill/
 │       └── SKILL.md         # Skill definitie
@@ -24,7 +30,7 @@ mijn-plugin/
 
 ## Stap 2: Plugin manifest
 
-Maak `.claude-plugin/plugin.json`:
+Maak `.plugin/plugin.json`:
 
 ```json
 {
@@ -94,29 +100,27 @@ claude plugin validate ./mijn-plugin
 
 ## Bestaande skills migreren
 
-Heb je al `.claude/skills/` in je project? Je kunt ze **in-place** omzetten naar plugin-formaat zonder ze te verplaatsen:
+Heb je al `.claude/skills/` in je project? Verplaats ze naar `skills/` voor cross-platform compatibiliteit:
 
-1. Maak `.claude-plugin/plugin.json` aan met een `skills` veld dat naar `.claude/skills/` verwijst:
-   ```json
-   {
-     "name": "mijn-plugin",
-     "description": "Beschrijving",
-     "version": "1.0.0",
-     "skills": "./.claude/skills/"
-   }
-   ```
-2. Zet elke `skill-naam.md` om naar een directory `skill-naam/SKILL.md`
-3. Voeg YAML frontmatter toe aan elke SKILL.md (name, description, model, allowed-tools)
-4. Test lokaal met `--plugin-dir`
+1. `git mv .claude/skills/ skills/`
+2. Maak `.plugin/plugin.json` aan (zonder `skills` veld — de standaardlocatie `skills/` wordt automatisch gevonden)
+3. Zet elke `skill-naam.md` om naar een directory `skill-naam/SKILL.md`
+4. Voeg YAML frontmatter toe aan elke SKILL.md (name, description, model, allowed-tools)
+5. Draai `python scripts/generate_plugin.py` om platform-bestanden te genereren
+6. Test lokaal met `--plugin-dir`
 
-Zo heb je **één locatie** voor skills die zowel lokaal in het project als via de marketplace werkt. Zie [zad-actions](https://github.com/RijksICTGilde/zad-actions) voor een werkend voorbeeld.
+Zie [zad-actions](https://github.com/RijksICTGilde/zad-actions) voor een werkend voorbeeld.
 
-## Cursor compatibiliteit
+## Cross-platform architectuur
 
-`SKILL.md` bestanden met YAML frontmatter zijn cross-platform en werken in zowel Claude Code als Cursor. Om je plugin ook via Cursor beschikbaar te maken:
+`.plugin/plugin.json` is de source of truth. Platform-specifieke bestanden worden gegenereerd met `scripts/generate_plugin.py`:
 
-1. Voeg `.cursor-plugin/plugin.json` toe aan je repository (vergelijkbaar met `.claude-plugin/plugin.json`)
-2. De marketplace genereert automatisch een Cursor-variant met `displayName`, `keywords` en `repository` velden
+```bash
+python scripts/generate_plugin.py          # genereer platform-bestanden
+python scripts/generate_plugin.py --check  # controleer of alles in sync is
+```
+
+`SKILL.md` bestanden met YAML frontmatter zijn al cross-platform en werken in zowel Claude Code als Cursor.
 
 ## Meer informatie
 

--- a/docs/plugin-toevoegen.md
+++ b/docs/plugin-toevoegen.md
@@ -1,6 +1,6 @@
 # Een plugin toevoegen aan de marketplace
 
-Deze handleiding beschrijft hoe je een bestaande Claude Code plugin registreert in de overheid-plugins marketplace.
+Deze handleiding beschrijft hoe je een bestaande plugin registreert in de overheid-plugins marketplace.
 
 ## Voorwaarden
 
@@ -8,7 +8,7 @@ Je plugin moet voldoen aan de [kwaliteitseisen](../CONTRIBUTING.md):
 
 - Open-source licentie
 - Publieke GitHub repository
-- Geldige `.claude-plugin/plugin.json`
+- Geldige `.plugin/plugin.json` (en gegenereerde platform-bestanden)
 - Minimaal 1 werkende skill, command of agent
 - README met documentatie
 
@@ -92,7 +92,7 @@ claude plugin install jouw-plugin@overheid-plugins
 
 Als je een nieuwe versie van je plugin uitbrengt:
 
-1. Update de `version` in je eigen `plugin.json`
-2. Open een PR om de `version` in `marketplace.json` (root) bij te werken
-3. Draai `python .github/scripts/generate_marketplace.py` om de platform-bestanden bij te werken
+1. Update de `version` in je eigen `.plugin/plugin.json`
+2. Draai `python scripts/generate_plugin.py` in je plugin-repo om platform-bestanden bij te werken
+3. De marketplace detecteert automatisch versie-wijzigingen en maakt een PR aan
 4. Gebruikers krijgen de update via `claude plugin marketplace update`

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -5,37 +5,37 @@ categories:
 description:
   nl:
     features:
-      - Centrale catalogus van Claude Code plugins voor de Nederlandse overheid
+      - Centrale catalogus van AI-assistant plugins voor de Nederlandse overheid
       - Geautomatiseerde validatie van plugin-registraties
       - Kwaliteitsdashboard voor gepubliceerde plugins
       - Handleidingen voor het bouwen en toevoegen van plugins
       - Ondersteuning voor meerdere overheidsorganisaties en standaarden
     genericName: Plugin marketplace
     longDescription: >
-      Centrale catalogus (marketplace) van Claude Code plugins voor de Nederlandse
-      overheid. Via deze marketplace kunnen overheidsteams hun Claude Code plugins
+      Centrale catalogus (marketplace) van AI-assistant plugins voor de Nederlandse
+      overheid. Via deze marketplace kunnen overheidsteams hun AI-assistant plugins
       publiceren en ontdekken. Bevat plugins voor onder andere Logius standaarden,
       internetstandaarden (internet.nl), geo-standaarden (Geonovum), de Nederlandse
       Richtlijn Digitale Systemen (NeRDS), BIO2 beveiligingsbaseline, en meer.
       Inclusief geautomatiseerde validatie, kwaliteitseisen en documentatie voor
       pluginontwikkelaars.
-    shortDescription: Centrale catalogus van Claude Code plugins voor de Nederlandse overheid
+    shortDescription: Centrale catalogus van AI-assistant plugins voor de Nederlandse overheid
   en:
     features:
-      - Central catalog of Claude Code plugins for the Dutch government
+      - Central catalog of AI-assistant plugins for the Dutch government
       - Automated validation of plugin registrations
       - Quality dashboard for published plugins
       - Guides for building and adding plugins
       - Support for multiple government organizations and standards
     genericName: Plugin marketplace
     longDescription: >
-      Central catalog (marketplace) of Claude Code plugins for the Dutch government.
+      Central catalog (marketplace) of AI-assistant plugins for the Dutch government.
       Through this marketplace, government teams can publish and discover Claude Code
       plugins. Contains plugins for Logius standards, internet standards (internet.nl),
       geo-standards (Geonovum), the Dutch Digital Systems Guideline (NeRDS), BIO2
       security baseline, and more. Includes automated validation, quality requirements,
       and documentation for plugin developers.
-    shortDescription: Central catalog of Claude Code plugins for the Dutch government
+    shortDescription: Central catalog of AI-assistant plugins for the Dutch government
 developmentStatus: stable
 legal:
   license: EUPL-1.2


### PR DESCRIPTION
## Controleer alle platform-bestanden in upstream repos

Nu alle plugin repos cross-platform zijn, moet de marketplace CI
controleren of alle 3 de bestanden aanwezig zijn:

- `.plugin/plugin.json` (source of truth)
- `.claude-plugin/plugin.json` (Claude Code)
- `.cursor-plugin/plugin.json` (Cursor)

Daarnaast haalt `check_versions.py` nu de versie op uit
`.plugin/plugin.json` (met fallback naar `.claude-plugin/plugin.json`
voor repos die nog niet gemigreerd zijn).