### PR TITLE
Update disclaimer: Overheidsbreed standpunt i.p.v. Rijksbrede beleidskader

### DIFF
--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -18,11 +18,7 @@ Bij twijfel of tegenstrijdigheid geldt altijd de officiële, gepubliceerde versi
 
 ## Gebruik van generatieve AI
 
-Overheidsorganisaties die generatieve AI inzetten — waaronder het gebruik van plugins uit deze marketplace en de output die ermee wordt gegenereerd — dienen te voldoen aan het [Rijksbrede beleidskader voor de inzet van generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Dit betekent onder meer:
-
-- AI-gegenereerde antwoorden dienen altijd te worden geverifieerd aan de hand van de officiële bronnen
-- De verantwoordelijkheid voor het gebruik van de output ligt bij de gebruiker
-- De plugins vervangen geen juridisch, beleidsmatig of technisch advies
+Overheidsorganisaties die generatieve AI inzetten — waaronder het gebruik van plugins uit deze marketplace en de output die ermee wordt gegenereerd — dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file) en aan eigen beleid en kaders over AI.
 
 ## Verantwoordelijkheid
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Een nieuw platform toevoegen (bijv. Windsurf, Copilot) vereist alleen een nieuwe
 
 ## Disclaimer
 
-Dit is een experimenteel project om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de overheid. De plugins in deze marketplace bevatten informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Rijksbrede beleidskader voor generatieve AI](https://www.government.nl/documents/policy-notes/2025/01/31/government-wide-position-on-the-use-of-generative-ai). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
+Dit is een experimenteel project om te leren hoe generatieve AI gestuurd kan worden om te werken volgens de kaders, richtlijnen en standaarden van de overheid. De plugins in deze marketplace bevatten informatieve samenvattingen — **niet** de officiële standaarden zelf. De definities op [Forum Standaardisatie](https://www.forumstandaardisatie.nl/open-standaarden) zijn altijd leidend. Overheidsorganisaties die generatieve AI inzetten dienen te voldoen aan het [Overheidsbreed standpunt voor de inzet van generatieve AI](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file). Zie [DISCLAIMER.md](DISCLAIMER.md) voor de volledige disclaimer.
 
 ## Licentie
 


### PR DESCRIPTION
## Summary

- **Naam gewijzigd**: "Rijksbrede beleidskader voor de inzet van generatieve AI" → "Overheidsbreed standpunt voor de inzet van generatieve AI"
- **URL gewijzigd**: naar Nederlandse versie op [open.overheid.nl](https://open.overheid.nl/documenten/bc03ce31-0cf1-4946-9c94-e934a62ebe73/file)
- **Opsomming verwijderd**: de 3 bullet points ("Dit betekent onder meer:") stonden niet in het standpunt zelf
- **Toegevoegd**: "en aan eigen beleid en kaders over AI."

Op verzoek van Vedran Bilanovic. Dezelfde wijziging wordt doorgevoerd in alle 4 repos (marketplace, internet, geo, standaarden).

## Bestanden

- `DISCLAIMER.md` — volledige sectie "Gebruik van generatieve AI" aangepast
- `README.md` — korte disclaimer-verwijzing aangepast

## Test plan

- [x] Geen "Rijksbrede beleidskader" meer in de repo
- [x] Geen "Dit betekent onder meer" meer in de repo
- [x] "Overheidsbreed standpunt" aanwezig in DISCLAIMER.md en README.md