### PR TITLE
fix: use ROOT_DIR for relative platform file paths

### DIFF
--- a/.github/scripts/check_versions.py
+++ b/.github/scripts/check_versions.py
@@ -367,11 +367,11 @@ def regenerate_platform_files() -> list[str]:
 
     Returns list of generated file paths (relative).
     """
-    from generate_marketplace import generate_all, load_source, PLATFORMS
+    from generate_marketplace import generate_all, load_source, PLATFORMS, ROOT_DIR
 
     source_data = load_source()
     generate_all(source_data)
-    return [str(path.relative_to(path.parent.parent.parent))
+    return [str(path.relative_to(ROOT_DIR))
             for _, (path, _) in PLATFORMS.items()]
 
 


### PR DESCRIPTION
## Summary

- Fix bug in `regenerate_platform_files()` where `path.relative_to(path.parent.parent.parent)` went one level too high, producing paths like `skills-marketplace/.claude-plugin/marketplace.json` instead of `.claude-plugin/marketplace.json`
- Use the already-defined `ROOT_DIR` from `generate_marketplace.py` for correct relative path resolution

## Test plan

- [ ] Verify `regenerate_platform_files()` returns paths relative to the repo root (e.g. `.claude-plugin/marketplace.json`)
- [ ] Run the check-versions workflow and confirm platform files are correctly staged in git