### PR TITLE
Update internet (0.1.6) en geo (0.2.2) plugin versies

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -99,7 +99,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -121,7 +121,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -108,7 +108,7 @@
       "name": "internet",
       "displayName": "Internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -132,7 +132,7 @@
       "name": "geo",
       "displayName": "Geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -98,7 +98,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -120,7 +120,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "developer-overheid-nl"
       },


### PR DESCRIPTION
## Handmatige versie-bump

Bumpt marketplace versies naar upstream:

| Plugin | Oud | Nieuw | Repo |
|--------|-----|-------|------|
| internet | 0.1.5 | [0.1.6](https://github.com/developer-overheid-nl/skills-internet/releases) | [developer-overheid-nl/skills-internet](https://github.com/developer-overheid-nl/skills-internet) |
| geo | 0.2.1 | [0.2.2](https://github.com/developer-overheid-nl/skills-geo/releases) | [developer-overheid-nl/skills-geo](https://github.com/developer-overheid-nl/skills-geo) |

> **Opmerking:** Handmatig aangemaakt omdat de check-versions workflow geen toegang heeft tot private repos. Zodra de repos weer public zijn, werkt de automatische versie-check weer.