### PR TITLE
fix: verwijder bio-security-baseline plugin (repo bestaat niet meer)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,31 +139,6 @@
         "metadata",
         "nen3610"
       ]
-    },
-    {
-      "name": "bio-security-baseline",
-      "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
-      "version": "0.2.0",
-      "author": {
-        "name": "MinBZK"
-      },
-      "source": {
-        "source": "github",
-        "repo": "MinBZK/bio-security-baseline-plugin"
-      },
-      "category": "security",
-      "tags": [
-        "overheid",
-        "beveiliging",
-        "informatiebeveiliging",
-        "BIO",
-        "BIO2",
-        "ISO27001",
-        "NIS2",
-        "cybersecurity",
-        "security-baseline",
-        "compliance"
-      ]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -151,33 +151,6 @@
         "metadata",
         "nen3610"
       ]
-    },
-    {
-      "name": "bio-security-baseline",
-      "displayName": "Bio Security Baseline",
-      "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
-      "version": "0.2.0",
-      "author": {
-        "name": "MinBZK"
-      },
-      "source": {
-        "source": "github",
-        "repo": "MinBZK/bio-security-baseline-plugin"
-      },
-      "repository": "https://github.com/MinBZK/bio-security-baseline-plugin",
-      "keywords": [
-        "security",
-        "overheid",
-        "beveiliging",
-        "informatiebeveiliging",
-        "BIO",
-        "BIO2",
-        "ISO27001",
-        "NIS2",
-        "cybersecurity",
-        "security-baseline",
-        "compliance"
-      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Importeer de marketplace via **Dashboard → Settings → Plugins → Import** m
 | [nerds](https://github.com/MinBZK/NeRDS) | 14 | Skills voor de Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale systemen (toegankelijkheid, open source, cloud, veiligheid, privacy, en meer) | [MinBZK](https://github.com/MinBZK) |
 | [internet](https://github.com/developer-overheid-nl/skills-internet) | 5 | Skills voor moderne internetstandaarden (getest via internet.nl): compliance voor websites en mailservers (IPv6, DNSSEC, HTTPS, TLS, DMARC, DKIM, SPF, DANE) | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
 | [geo](https://github.com/developer-overheid-nl/skills-geo) | 6 | Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API, WMS, WFS, metadata (ISO 19115), informatiemodellen (NEN 3610, MIM), INSPIRE en 3D | [developer-overheid-nl](https://github.com/developer-overheid-nl) |
-| [bio-security-baseline](https://github.com/MinBZK/bio-security-baseline-plugin) | 1 | BIO2 security baseline: verplichte beveiligingsmaatregelen, Forum Standaardisatie-standaarden, NCSC-richtlijnen, NIS2/Cyberbeveiligingswet, EU CRA, AI Act en compliance-informatie | [MinBZK](https://github.com/MinBZK) |
 
 ## Plugin toevoegen
 

--- a/marketplace.json
+++ b/marketplace.json
@@ -138,31 +138,6 @@
         "metadata",
         "nen3610"
       ]
-    },
-    {
-      "name": "bio-security-baseline",
-      "description": "Skill voor de Baseline Informatiebeveiliging Overheid 2 (BIO2): verplichte beveiligingsmaatregelen voor alle Nederlandse overheidsorganisaties (informatiebeveiliging, toegangsbeheer, kwetsbaarhedenbeheer, logging, cryptografie, EU CRA, AI Act, eIDAS 2.0, en meer)",
-      "version": "0.2.0",
-      "author": {
-        "name": "MinBZK"
-      },
-      "source": {
-        "source": "github",
-        "repo": "MinBZK/bio-security-baseline-plugin"
-      },
-      "category": "security",
-      "tags": [
-        "overheid",
-        "beveiliging",
-        "informatiebeveiliging",
-        "BIO",
-        "BIO2",
-        "ISO27001",
-        "NIS2",
-        "cybersecurity",
-        "security-baseline",
-        "compliance"
-      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Verwijdert de `bio-security-baseline` plugin uit de marketplace omdat de repository `MinBZK/bio-security-baseline-plugin` niet meer bestaat
- Installatie faalde met "Repository not found" error
- Verwijderd uit `marketplace.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json` en `README.md`

## Test plan

- [ ] Verify JSON is still valid
- [ ] Check dat de overige plugins nog correct in de marketplace staan