### PR TITLE
fix: update developer-overheid repo URL

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
       },
       "source": {
         "source": "github",
-        "repo": "dstotijn/developer-overheid-nl-agent-skills"
+        "repo": "developer-overheid-nl/developer-overheid-nl-agent-skills"
       },
       "category": "productivity",
       "tags": [

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -64,9 +64,9 @@
       },
       "source": {
         "source": "github",
-        "repo": "dstotijn/developer-overheid-nl-agent-skills"
+        "repo": "developer-overheid-nl/developer-overheid-nl-agent-skills"
       },
-      "repository": "https://github.com/dstotijn/developer-overheid-nl-agent-skills",
+      "repository": "https://github.com/developer-overheid-nl/developer-overheid-nl-agent-skills",
       "keywords": [
         "productivity",
         "overheid",

--- a/marketplace.json
+++ b/marketplace.json
@@ -58,7 +58,7 @@
       },
       "source": {
         "source": "github",
-        "repo": "dstotijn/developer-overheid-nl-agent-skills"
+        "repo": "developer-overheid-nl/developer-overheid-nl-agent-skills"
       },
       "category": "productivity",
       "tags": [


### PR DESCRIPTION
## Summary
- Repo `developer-overheid-nl-agent-skills` is verhuisd van `dstotijn/` naar `developer-overheid-nl/`
- URL in marketplace.json bijgewerkt