### PR TITLE
chore: bump standaarden 0.3.9, internet 0.1.8, geo 0.2.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -99,7 +99,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -121,7 +121,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "standaarden",
       "displayName": "Standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -108,7 +108,7 @@
       "name": "internet",
       "displayName": "Internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -132,7 +132,7 @@
       "name": "geo",
       "displayName": "Geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -98,7 +98,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -120,7 +120,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "author": {
         "name": "developer-overheid-nl"
       },


### PR DESCRIPTION
## Samenvatting

Marketplace versies bijgewerkt na release-please releases:
- standaarden: 0.3.8 → **0.3.9** (OIN-Stelsel v2.2.2, Liferay normalize_html fix)
- internet: 0.1.7 → **0.1.8** (Liferay normalize_html fix)
- geo: 0.2.3 → **0.2.4** (Liferay normalize_html fix)