### PR TITLE
Update 3 plugins: geo v0.3.12, internet v0.2.8, standaarden v0.6.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -99,7 +99,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -121,7 +121,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "standaarden",
       "displayName": "Standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -108,7 +108,7 @@
       "name": "internet",
       "displayName": "Internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -132,7 +132,7 @@
       "name": "geo",
       "displayName": "Geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "author": {
         "name": "developer-overheid-nl"
       },

--- a/marketplace.json
+++ b/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "standaarden",
       "description": "CONCEPT — Skills voor Nederlandse overheidsstandaarden (beheerd door Logius): API Design Rules, Digikoppeling, OAuth NL, FSC, Logboek Dataverwerkingen, CloudEvents, BOMOS, E-Government en Publicatie-tooling. Bevat 10 skills voor 77 GitHub repositories verdeeld over 9 domeinen.",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -98,7 +98,7 @@
     {
       "name": "internet",
       "description": "CONCEPT — Skills voor moderne internetstandaarden (getest via internet.nl): webstandaarden (HTTPS, TLS, DNSSEC, IPv6, RPKI), mailstandaarden (DMARC, DKIM, SPF, STARTTLS, DANE), batch API en implementatiegidsen uit de toolbox-wiki.",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "author": {
         "name": "developer-overheid-nl"
       },
@@ -120,7 +120,7 @@
     {
       "name": "geo",
       "description": "CONCEPT — Skills voor Nederlandse geo-standaarden (beheerd door Geonovum): OGC API services (WMS, WFS, WMTS, OGC API Features), metadata (ISO 19115, NGR), informatiemodellen (NEN 3610, MIM), INSPIRE implementatie en 3D standaarden (CityGML, 3D Tiles).",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "author": {
         "name": "developer-overheid-nl"
       },


### PR DESCRIPTION
Bump na de release van de \`pull/N\`-normalisatiefix in \`extract_urls.py\` in alle drie de content-repos (skills-geo#326, skills-internet#254, skills-standaarden#832).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AetriQcQDn5jYzVDh1t4yf